### PR TITLE
fix(catalog): retain global CRIS profiles alongside regional (#21)

### DIFF
--- a/src/bestehorn_llmmanager/bedrock/catalog/api_fetcher.py
+++ b/src/bestehorn_llmmanager/bedrock/catalog/api_fetcher.py
@@ -334,25 +334,39 @@ class BedrockAPIFetcher:
             # Get Bedrock control plane client for this region
             client = self._auth_manager.get_bedrock_control_client(region=region)
 
-            # Call list-inference-profiles API with SYSTEM_DEFINED filter
-            response = client.list_inference_profiles(
-                **{CatalogAPIParameters.PROFILE_TYPE_EQUALS: CatalogAPIParameters.SYSTEM_DEFINED}
-            )
+            # Call list-inference-profiles with the SYSTEM_DEFINED filter, following
+            # nextToken pagination so no profiles are lost when a region returns more than
+            # one page (issue #21 — later pages can include global.* profiles). The first
+            # call carries only the type filter (backward compatible); subsequent calls add
+            # the prior page's nextToken.
+            all_summaries: List[Dict[str, Any]] = []
+            request_args: Dict[str, Any] = {
+                CatalogAPIParameters.PROFILE_TYPE_EQUALS: CatalogAPIParameters.SYSTEM_DEFINED
+            }
 
-            # Extract inference profile summaries from response
-            profile_summaries = response.get(
-                CatalogAPIResponseFields.INFERENCE_PROFILE_SUMMARIES, []
-            )
+            while True:
+                response = client.list_inference_profiles(**request_args)
 
-            if not isinstance(profile_summaries, list):
-                raise APIFetchError(
-                    message=CatalogErrorMessages.API_FETCH_INVALID_RESPONSE.format(
-                        error="INFERENCE_PROFILE_SUMMARIES is not a list"
-                    ),
-                    region=region,
+                profile_summaries = response.get(
+                    CatalogAPIResponseFields.INFERENCE_PROFILE_SUMMARIES, []
                 )
 
-            return profile_summaries
+                if not isinstance(profile_summaries, list):
+                    raise APIFetchError(
+                        message=CatalogErrorMessages.API_FETCH_INVALID_RESPONSE.format(
+                            error="INFERENCE_PROFILE_SUMMARIES is not a list"
+                        ),
+                        region=region,
+                    )
+
+                all_summaries.extend(profile_summaries)
+
+                next_token = response.get(CatalogAPIResponseFields.NEXT_TOKEN)
+                if not next_token:
+                    break
+                request_args[CatalogAPIParameters.NEXT_TOKEN] = next_token
+
+            return all_summaries
 
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "Unknown")

--- a/src/bestehorn_llmmanager/bedrock/catalog/transformer.py
+++ b/src/bestehorn_llmmanager/bedrock/catalog/transformer.py
@@ -509,16 +509,26 @@ class CatalogTransformer:
 
             if model_arn:
                 # Extract region from ARN
+                # Format: arn:aws:bedrock:region:account:foundation-model/model-id
+                # Issue #21: global inference profiles carry a region-less model ARN
+                # (arn:aws:bedrock:::foundation-model/...), so arn_parts[3] is an EMPTY
+                # string. Skipping empty regions prevents an invalid empty destination
+                # region from being recorded (which previously caused CRISInferenceProfile
+                # validation to reject the whole global profile, dropping it entirely).
+                # With no explicit mapping, the caller falls back to
+                # {source_region: [source_region]}, keeping the global profile available
+                # from the region it was listed in.
                 arn_parts = model_arn.split(":")
                 if len(arn_parts) >= 4:
                     model_region = arn_parts[3]
 
-                    # Add mapping: source_region -> model_region
-                    if source_region not in region_mappings:
-                        region_mappings[source_region] = []
+                    if model_region:
+                        # Add mapping: source_region -> model_region
+                        if source_region not in region_mappings:
+                            region_mappings[source_region] = []
 
-                    if model_region not in region_mappings[source_region]:
-                        region_mappings[source_region].append(model_region)
+                        if model_region not in region_mappings[source_region]:
+                            region_mappings[source_region].append(model_region)
 
         # If we found mappings, sort them for consistency
         if region_mappings:
@@ -574,25 +584,30 @@ class CatalogTransformer:
         """
         Extract model name from inference profile ID.
 
-        Handles both global and regional profile ID formats:
-        - Global: "global.anthropic.claude-3-5-haiku-20241022-v1:0"
-        - Regional: "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+        The region/geo prefix (global., us., eu., apac., jp., au., …) is stripped so that
+        ALL profiles for the same foundation model — regional AND global — map to the SAME
+        model name and are grouped into a single CRISModelInfo (issue #21). This lets a
+        model carry both its geographic CRIS profiles and its global CRIS profile, which the
+        correlator then exposes per region so callers can choose between them (geographic for
+        data residency vs. global for cost/throughput — see AWS cross-Region inference docs).
+
+        Note: previously a "global." profile was prefixed with "Global " to form a separate
+        CRIS model. That caused the global profile to either be dropped (no matching base
+        model) or to REPLACE the regional profiles via global-priority matching. Grouping by
+        the prefix-stripped name avoids both.
 
         Examples:
-            "global.anthropic.claude-3-5-haiku-20241022-v1:0" -> "Global Anthropic Claude 3 5 Haiku 20241022"
-            "us.anthropic.claude-3-5-haiku-20241022-v1:0" -> "Anthropic Claude 3 5 Haiku 20241022"
-            "eu.amazon.titan-text-express-v1" -> "Amazon Titan Text Express"
+            "global.anthropic.claude-3-5-haiku-20241022-v1:0" -> "Anthropic Claude 3 5 Haiku 20241022"
+            "us.anthropic.claude-3-5-haiku-20241022-v1:0"     -> "Anthropic Claude 3 5 Haiku 20241022"
+            "eu.amazon.titan-text-express-v1"                 -> "Amazon Titan Text Express"
 
         Args:
             profile_id: Inference profile ID
 
         Returns:
-            Model name with appropriate prefix
+            Model name (provider + model), without any region/geo prefix
         """
-        # Check if this is a global profile
-        is_global = profile_id.startswith("global.")
-
-        # Remove regional prefix (global., us., eu., apac., etc.)
+        # Remove regional/global prefix (global., us., eu., apac., jp., au., etc.)
         parts = profile_id.split(".", 2)  # Split into at most 3 parts
         if len(parts) >= 3:
             # Format: region.provider.model-id
@@ -620,14 +635,8 @@ class CatalogTransformer:
         capitalized_words = [word.capitalize() for word in words if word]
         model_name = " ".join(capitalized_words)
 
-        # Construct full name with provider
-        full_name = f"{provider} {model_name}"
-
-        # Add "Global" prefix if it's a global profile
-        if is_global:
-            full_name = f"Global {full_name}"
-
-        return full_name
+        # Construct full name with provider (no "Global " prefix — see docstring)
+        return f"{provider} {model_name}"
 
     def _merge_model_info(
         self,

--- a/src/bestehorn_llmmanager/bedrock/correlators/model_cris_correlator.py
+++ b/src/bestehorn_llmmanager/bedrock/correlators/model_cris_correlator.py
@@ -3,6 +3,7 @@ Model-CRIS correlation logic for unified Bedrock model management.
 Handles matching and merging data between regular model information and CRIS data.
 """
 
+import dataclasses
 import logging
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -801,7 +802,97 @@ class ModelCRISCorrelator:
                 f"Model '{model_info.model_id}' had {len(skipped_regions)} skipped regions: {skipped_regions}"
             )
 
+        # Issue #21: a region can be served by BOTH a geographic (regional) CRIS profile and
+        # the global CRIS profile. The per-region branches above build access from a single
+        # profile (get_profiles_for_source_region()[0]), so one of the two is otherwise lost.
+        # Reconcile each region to carry every CRIS profile available from it: regional AND
+        # global flags set together when both exist. Geographic vs global are distinct,
+        # caller-selectable profiles (residency vs cost/throughput), so the catalog exposes
+        # both. Purely additive — direct access and any already-set flags are preserved.
+        self._merge_all_cris_profiles_per_region(
+            region_access=region_access, cris_model_info=cris_model_info
+        )
+
         return region_access
+
+    def _merge_all_cris_profiles_per_region(
+        self,
+        region_access: Dict[str, ModelAccessInfo],
+        cris_model_info: Optional[CRISModelInfo],
+    ) -> None:
+        """
+        Ensure each region's ModelAccessInfo carries every CRIS profile available from it.
+
+        For each region already in region_access, look up the regional and global CRIS
+        profiles that can route from it and set has_regional_cris / has_global_cris (with
+        their profile ids) accordingly, preserving existing direct access. ModelAccessInfo
+        is frozen, so a replacement instance is built via dataclasses.replace.
+
+        Args:
+            region_access: region -> ModelAccessInfo built by the access-method branches
+                (mutated in place).
+            cris_model_info: CRIS model information, or None.
+        """
+        if not cris_model_info:
+            return
+
+        for region, access_info in list(region_access.items()):
+            regional_id, global_id = self._split_region_profiles(
+                cris_model_info=cris_model_info, region=region
+            )
+
+            # Compute the reconciled flags/ids, keeping any already-present values.
+            has_regional = access_info.has_regional_cris or regional_id is not None
+            has_global = access_info.has_global_cris or global_id is not None
+            regional_profile = access_info.regional_cris_profile_id or regional_id
+            global_profile = access_info.global_cris_profile_id or global_id
+
+            # Nothing to add for this region.
+            if (has_regional == access_info.has_regional_cris) and (
+                has_global == access_info.has_global_cris
+            ):
+                continue
+
+            region_access[region] = dataclasses.replace(
+                access_info,
+                has_regional_cris=has_regional,
+                regional_cris_profile_id=regional_profile,
+                has_global_cris=has_global,
+                global_cris_profile_id=global_profile,
+            )
+            self._logger.debug(
+                f"Reconciled CRIS profiles for region '{region}': "
+                f"regional={regional_profile}, global={global_profile}"
+            )
+
+    def _split_region_profiles(
+        self, cris_model_info: Optional[CRISModelInfo], region: str
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """
+        Split the CRIS profiles routable from a region into (regional_id, global_id).
+
+        A profile id prefixed 'global.' is the global profile; any other is regional
+        (geographic). Returns the first of each kind found, or None when absent.
+
+        Args:
+            cris_model_info: CRIS model information, or None.
+            region: The source region to query.
+
+        Returns:
+            (regional_profile_id, global_profile_id); either element may be None.
+        """
+        if not cris_model_info:
+            return (None, None)
+
+        regional_id: Optional[str] = None
+        global_id: Optional[str] = None
+        for profile_id in cris_model_info.get_profiles_for_source_region(source_region=region):
+            if profile_id.startswith(CRISGlobalConstants.GLOBAL_PROFILE_PREFIX):
+                if global_id is None:
+                    global_id = profile_id
+            elif regional_id is None:
+                regional_id = profile_id
+        return (regional_id, global_id)
 
     def _get_inference_profile_for_region(
         self, cris_model_info: Optional[CRISModelInfo], region: str

--- a/src/bestehorn_llmmanager/bedrock/models/catalog_constants.py
+++ b/src/bestehorn_llmmanager/bedrock/models/catalog_constants.py
@@ -46,6 +46,9 @@ class CatalogAPIResponseFields:
     INFERENCE_TYPES_SUPPORTED: Final[str] = "inferenceTypesSupported"
     MODEL_LIFECYCLE: Final[str] = "modelLifecycle"
 
+    # Pagination token returned by list APIs (present when more pages remain)
+    NEXT_TOKEN: Final[str] = "nextToken"
+
     # list-inference-profiles response fields
     INFERENCE_PROFILE_SUMMARIES: Final[str] = "inferenceProfileSummaries"
     INFERENCE_PROFILE_NAME: Final[str] = "inferenceProfileName"

--- a/src/bestehorn_llmmanager/bedrock/models/unified_constants.py
+++ b/src/bestehorn_llmmanager/bedrock/models/unified_constants.py
@@ -25,9 +25,18 @@ class UnifiedJSONFields:
 
     # Region access information
     REGION_ACCESS: Final[str] = "region_access"
-    ACCESS_METHOD: Final[str] = "access_method"
+    ACCESS_METHOD: Final[str] = "access_method"  # legacy (deprecated) single-method field
     REGION: Final[str] = "region"
-    INFERENCE_PROFILE_ID: Final[str] = "inference_profile_id"
+    INFERENCE_PROFILE_ID: Final[str] = "inference_profile_id"  # legacy single-profile field
+
+    # Orthogonal access-method fields (issue #21). These let a region carry any combination
+    # of direct + regional (geographic) CRIS + global CRIS simultaneously, which the legacy
+    # single ACCESS_METHOD/INFERENCE_PROFILE_ID pair could not represent.
+    HAS_DIRECT_ACCESS: Final[str] = "has_direct_access"
+    HAS_REGIONAL_CRIS: Final[str] = "has_regional_cris"
+    HAS_GLOBAL_CRIS: Final[str] = "has_global_cris"
+    REGIONAL_CRIS_PROFILE_ID: Final[str] = "regional_cris_profile_id"
+    GLOBAL_CRIS_PROFILE_ID: Final[str] = "global_cris_profile_id"
 
     # Access method values
     ACCESS_DIRECT: Final[str] = "direct"

--- a/src/bestehorn_llmmanager/bedrock/models/unified_structures.py
+++ b/src/bestehorn_llmmanager/bedrock/models/unified_structures.py
@@ -179,6 +179,29 @@ class UnifiedModelInfo:
                 profiles.add(access_info.global_cris_profile_id)
         return sorted(list(profiles))
 
+    @staticmethod
+    def _legacy_access_method_value(access_info: ModelAccessInfo) -> str:
+        """
+        Compute the legacy access_method string from the orthogonal flags.
+
+        Mirrors the deprecated ModelAccessInfo.access_method property mapping WITHOUT
+        invoking it (so no deprecation warning is emitted): direct + any CRIS -> "both",
+        any CRIS only -> "cris_only", direct only -> "direct". Written for backward
+        compatibility so older readers of the bundled JSON still find an access_method.
+
+        Args:
+            access_info: The access info to map.
+
+        Returns:
+            One of UnifiedJSONFields.ACCESS_DIRECT / ACCESS_CRIS_ONLY / ACCESS_BOTH.
+        """
+        has_cris = access_info.has_regional_cris or access_info.has_global_cris
+        if access_info.has_direct_access and has_cris:
+            return UnifiedJSONFields.ACCESS_BOTH
+        if has_cris:
+            return UnifiedJSONFields.ACCESS_CRIS_ONLY
+        return UnifiedJSONFields.ACCESS_DIRECT
+
     def to_dict(self) -> Dict[str, Union[str, List[str], bool, Dict, None]]:
         """
         Convert the unified model info to a dictionary suitable for JSON serialization.
@@ -188,12 +211,29 @@ class UnifiedModelInfo:
         """
         region_access_dict = {}
         for region, access_info in self.region_access.items():
-            region_access_dict[region] = {
-                UnifiedJSONFields.ACCESS_METHOD: access_info.access_method.value,
+            # Issue #21: serialize the orthogonal access flags so a region can carry direct
+            # + regional (geographic) CRIS + global CRIS simultaneously. The legacy
+            # ACCESS_METHOD / INFERENCE_PROFILE_ID pair is still written for backward
+            # compatibility with older readers (it collapses to a single method/profile),
+            # but from_dict prefers the orthogonal fields when present.
+            entry: Dict[str, Union[str, bool, None]] = {
                 UnifiedJSONFields.REGION: access_info.region,
+                UnifiedJSONFields.HAS_DIRECT_ACCESS: access_info.has_direct_access,
+                UnifiedJSONFields.HAS_REGIONAL_CRIS: access_info.has_regional_cris,
+                UnifiedJSONFields.HAS_GLOBAL_CRIS: access_info.has_global_cris,
                 UnifiedJSONFields.MODEL_ID: access_info.model_id,
-                UnifiedJSONFields.INFERENCE_PROFILE_ID: access_info.inference_profile_id,
+                UnifiedJSONFields.REGIONAL_CRIS_PROFILE_ID: access_info.regional_cris_profile_id,
+                UnifiedJSONFields.GLOBAL_CRIS_PROFILE_ID: access_info.global_cris_profile_id,
             }
+            # Legacy fields (deprecated) — derived from the orthogonal flags without
+            # emitting deprecation warnings (we read the underlying attributes directly).
+            entry[UnifiedJSONFields.ACCESS_METHOD] = self._legacy_access_method_value(
+                access_info=access_info
+            )
+            entry[UnifiedJSONFields.INFERENCE_PROFILE_ID] = (
+                access_info.regional_cris_profile_id or access_info.global_cris_profile_id
+            )
+            region_access_dict[region] = entry
 
         return {
             UnifiedJSONFields.MODEL_NAME: self.model_name,
@@ -206,6 +246,50 @@ class UnifiedModelInfo:
             UnifiedJSONFields.HYPERPARAMETERS_LINK: self.hyperparameters_link,
             UnifiedJSONFields.REGION_ACCESS: region_access_dict,
         }
+
+    @staticmethod
+    def _access_info_from_dict(access_data: Dict) -> ModelAccessInfo:
+        """
+        Build a ModelAccessInfo from a serialized region-access entry.
+
+        Prefers the orthogonal access fields (has_direct_access / has_regional_cris /
+        has_global_cris + their ids — issue #21), which can represent a region served by
+        both regional and global CRIS. Falls back to the legacy access_method /
+        inference_profile_id pair for older cached catalogs that predate the orthogonal
+        fields.
+
+        Args:
+            access_data: One region's serialized access dictionary.
+
+        Returns:
+            A ModelAccessInfo instance.
+        """
+        region = access_data[UnifiedJSONFields.REGION]
+
+        # New format: orthogonal flags present.
+        if UnifiedJSONFields.HAS_GLOBAL_CRIS in access_data or (
+            UnifiedJSONFields.HAS_REGIONAL_CRIS in access_data
+        ):
+            return ModelAccessInfo(
+                region=region,
+                has_direct_access=bool(access_data.get(UnifiedJSONFields.HAS_DIRECT_ACCESS, False)),
+                has_regional_cris=bool(access_data.get(UnifiedJSONFields.HAS_REGIONAL_CRIS, False)),
+                has_global_cris=bool(access_data.get(UnifiedJSONFields.HAS_GLOBAL_CRIS, False)),
+                model_id=access_data.get(UnifiedJSONFields.MODEL_ID),
+                regional_cris_profile_id=access_data.get(
+                    UnifiedJSONFields.REGIONAL_CRIS_PROFILE_ID
+                ),
+                global_cris_profile_id=access_data.get(UnifiedJSONFields.GLOBAL_CRIS_PROFILE_ID),
+            )
+
+        # Legacy format: single access_method + inference_profile_id.
+        access_method = ModelAccessMethod(access_data[UnifiedJSONFields.ACCESS_METHOD])
+        return ModelAccessInfo.from_legacy(
+            access_method=access_method,
+            region=region,
+            model_id=access_data.get(UnifiedJSONFields.MODEL_ID),
+            inference_profile_id=access_data.get(UnifiedJSONFields.INFERENCE_PROFILE_ID),
+        )
 
     @classmethod
     def from_dict(
@@ -234,13 +318,7 @@ class UnifiedModelInfo:
                 if not isinstance(access_data, dict):
                     raise ValueError(f"Access data for region {region} must be a dictionary")
 
-                access_method = ModelAccessMethod(access_data[UnifiedJSONFields.ACCESS_METHOD])
-                region_access[region] = ModelAccessInfo.from_legacy(
-                    access_method=access_method,
-                    region=access_data[UnifiedJSONFields.REGION],
-                    model_id=access_data.get(UnifiedJSONFields.MODEL_ID),
-                    inference_profile_id=access_data.get(UnifiedJSONFields.INFERENCE_PROFILE_ID),
-                )
+                region_access[region] = cls._access_info_from_dict(access_data=access_data)
 
             # Extract and validate data with proper type conversion
             model_id_raw = data.get(UnifiedJSONFields.MODEL_ID)

--- a/src/bestehorn_llmmanager/bedrock/package_data/bedrock_catalog_bundled.json
+++ b/src/bestehorn_llmmanager/bedrock/package_data/bedrock_catalog_bundled.json
@@ -16,57 +16,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-12b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-12b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-12b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-12b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-12b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-12b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-12b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-12b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-12b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -87,87 +132,157 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "cris_only",
           "region": "ap-northeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "apac.anthropic.claude-sonnet-4-20250514-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-20250514-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "apac.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "ap-northeast-2": {
-          "access_method": "cris_only",
           "region": "ap-northeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "apac.anthropic.claude-sonnet-4-20250514-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "apac.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "ap-northeast-3": {
-          "access_method": "cris_only",
           "region": "ap-northeast-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "apac.anthropic.claude-sonnet-4-20250514-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "apac.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "ap-south-1": {
-          "access_method": "cris_only",
           "region": "ap-south-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "apac.anthropic.claude-sonnet-4-20250514-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "apac.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "ap-southeast-1": {
-          "access_method": "cris_only",
           "region": "ap-southeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "apac.anthropic.claude-sonnet-4-20250514-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "apac.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "ap-southeast-2": {
-          "access_method": "cris_only",
           "region": "ap-southeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "apac.anthropic.claude-sonnet-4-20250514-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "apac.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "eu-central-1": {
-          "access_method": "cris_only",
           "region": "eu-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-sonnet-4-20250514-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "eu-north-1": {
-          "access_method": "cris_only",
           "region": "eu-north-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-sonnet-4-20250514-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "eu-west-1": {
-          "access_method": "cris_only",
           "region": "eu-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-sonnet-4-20250514-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-20250514-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "eu-west-3": {
-          "access_method": "cris_only",
           "region": "eu-west-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-sonnet-4-20250514-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-20250514-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-20250514-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "us-west-1": {
-          "access_method": "cris_only",
           "region": "us-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-sonnet-4-20250514-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-20250514-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-sonnet-4-20250514-v1:0"
         }
       }
@@ -188,75 +303,190 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "cris_only",
           "region": "ap-northeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "jp.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "jp.anthropic.claude-haiku-4-5-20251001-v1:0"
+        },
+        "ap-northeast-2": {
+          "region": "ap-northeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0"
         },
         "ap-northeast-3": {
-          "access_method": "cris_only",
           "region": "ap-northeast-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "jp.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "jp.anthropic.claude-haiku-4-5-20251001-v1:0"
         },
-        "ap-southeast-2": {
-          "access_method": "cris_only",
-          "region": "ap-southeast-2",
+        "ap-south-1": {
+          "region": "ap-south-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+        },
+        "ap-southeast-1": {
+          "region": "ap-southeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+        },
+        "ap-southeast-2": {
+          "region": "ap-southeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "au.anthropic.claude-haiku-4-5-20251001-v1:0"
         },
         "ca-central-1": {
-          "access_method": "cris_only",
           "region": "ca-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
         },
         "eu-central-1": {
-          "access_method": "cris_only",
           "region": "eu-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
         },
         "eu-north-1": {
-          "access_method": "cris_only",
           "region": "eu-north-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
         },
         "eu-west-1": {
-          "access_method": "cris_only",
           "region": "eu-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
         },
         "eu-west-2": {
-          "access_method": "cris_only",
           "region": "eu-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
         },
         "eu-west-3": {
-          "access_method": "cris_only",
           "region": "eu-west-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
         },
-        "us-east-1": {
-          "access_method": "cris_only",
-          "region": "us-east-1",
+        "sa-east-1": {
+          "region": "sa-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+        },
+        "us-east-1": {
+          "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        },
+        "us-east-2": {
+          "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
         },
         "us-west-1": {
-          "access_method": "cris_only",
           "region": "us-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
         }
       }
@@ -276,51 +506,91 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-235b-a22b-2507-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-235b-a22b-2507-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-235b-a22b-2507-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-235b-a22b-2507-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-235b-a22b-2507-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-235b-a22b-2507-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-235b-a22b-2507-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-235b-a22b-2507-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -341,57 +611,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "moonshotai.kimi-k2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "moonshotai.kimi-k2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "moonshotai.kimi-k2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "moonshotai.kimi-k2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "moonshotai.kimi-k2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "moonshotai.kimi-k2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "moonshotai.kimi-k2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "moonshotai.kimi-k2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "moonshotai.kimi-k2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -411,69 +726,124 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-120b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-120b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-120b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-120b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-120b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-120b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-120b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-120b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-120b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-120b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-120b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -494,21 +864,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-creative-upscale-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-creative-upscale-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-creative-upscale-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-creative-upscale-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-creative-upscale-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-creative-upscale-v1:0"
         }
       }
@@ -528,57 +913,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-next-80b-a3b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-next-80b-a3b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-next-80b-a3b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-next-80b-a3b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-next-80b-a3b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-next-80b-a3b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-next-80b-a3b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-next-80b-a3b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-next-80b-a3b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -598,64 +1028,191 @@
       "inference_parameters_link": null,
       "hyperparameters_link": null,
       "region_access": {
-        "ap-southeast-2": {
-          "access_method": "cris_only",
-          "region": "ap-southeast-2",
+        "ap-northeast-1": {
+          "region": "ap-northeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-fable-5"
+        },
+        "ap-northeast-2": {
+          "region": "ap-northeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-fable-5"
+        },
+        "ap-northeast-3": {
+          "region": "ap-northeast-3",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-fable-5"
+        },
+        "ap-south-1": {
+          "region": "ap-south-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-fable-5"
+        },
+        "ap-southeast-1": {
+          "region": "ap-southeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-fable-5"
+        },
+        "ap-southeast-2": {
+          "region": "ap-southeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "au.anthropic.claude-fable-5",
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
           "inference_profile_id": "au.anthropic.claude-fable-5"
         },
         "ca-central-1": {
-          "access_method": "cris_only",
           "region": "ca-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-fable-5",
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-fable-5"
         },
         "eu-central-1": {
-          "access_method": "cris_only",
           "region": "eu-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-fable-5",
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-fable-5"
         },
         "eu-north-1": {
-          "access_method": "cris_only",
           "region": "eu-north-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-fable-5",
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-fable-5"
         },
         "eu-west-1": {
-          "access_method": "cris_only",
           "region": "eu-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-fable-5",
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-fable-5"
         },
         "eu-west-2": {
-          "access_method": "cris_only",
           "region": "eu-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-fable-5",
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-fable-5"
         },
         "eu-west-3": {
-          "access_method": "cris_only",
           "region": "eu-west-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-fable-5",
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-fable-5"
         },
-        "us-east-1": {
-          "access_method": "cris_only",
-          "region": "us-east-1",
+        "sa-east-1": {
+          "region": "sa-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-fable-5"
+        },
+        "us-east-1": {
+          "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-fable-5",
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
+          "inference_profile_id": "us.anthropic.claude-fable-5"
+        },
+        "us-east-2": {
+          "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-fable-5",
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-fable-5"
         },
         "us-west-1": {
-          "access_method": "cris_only",
           "region": "us-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-fable-5",
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-fable-5"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-fable-5",
+          "global_cris_profile_id": "global.anthropic.claude-fable-5",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-fable-5"
         }
       }
@@ -675,57 +1232,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "deepseek.v3.2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "deepseek.v3.2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "deepseek.v3.2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "deepseek.v3.2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "deepseek.v3.2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "deepseek.v3.2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "deepseek.v3.2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "deepseek.v3.2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "deepseek.v3.2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -745,57 +1347,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-3-30b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-3-30b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-3-30b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-3-30b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-3-30b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-3-30b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-3-30b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-3-30b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-3-30b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -816,105 +1463,190 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "both",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
+          "regional_cris_profile_id": "jp.anthropic.claude-sonnet-4-6",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
           "inference_profile_id": "jp.anthropic.claude-sonnet-4-6"
         },
         "ap-northeast-2": {
-          "access_method": "direct",
           "region": "ap-northeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
+          "inference_profile_id": "global.anthropic.claude-sonnet-4-6"
         },
         "ap-northeast-3": {
-          "access_method": "both",
           "region": "ap-northeast-3",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
+          "regional_cris_profile_id": "jp.anthropic.claude-sonnet-4-6",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
           "inference_profile_id": "jp.anthropic.claude-sonnet-4-6"
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
+          "inference_profile_id": "global.anthropic.claude-sonnet-4-6"
         },
         "ap-southeast-1": {
-          "access_method": "direct",
           "region": "ap-southeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
+          "inference_profile_id": "global.anthropic.claude-sonnet-4-6"
         },
         "ap-southeast-2": {
-          "access_method": "both",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
+          "regional_cris_profile_id": "au.anthropic.claude-sonnet-4-6",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
           "inference_profile_id": "au.anthropic.claude-sonnet-4-6"
         },
         "ca-central-1": {
-          "access_method": "both",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
+          "regional_cris_profile_id": "us.anthropic.claude-sonnet-4-6",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-sonnet-4-6"
         },
         "eu-central-1": {
-          "access_method": "both",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
+          "regional_cris_profile_id": "eu.anthropic.claude-sonnet-4-6",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
           "inference_profile_id": "eu.anthropic.claude-sonnet-4-6"
         },
         "eu-north-1": {
-          "access_method": "both",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
+          "regional_cris_profile_id": "eu.anthropic.claude-sonnet-4-6",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
           "inference_profile_id": "eu.anthropic.claude-sonnet-4-6"
         },
         "eu-west-1": {
-          "access_method": "both",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
+          "regional_cris_profile_id": "eu.anthropic.claude-sonnet-4-6",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
           "inference_profile_id": "eu.anthropic.claude-sonnet-4-6"
         },
         "eu-west-2": {
-          "access_method": "both",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
+          "regional_cris_profile_id": "eu.anthropic.claude-sonnet-4-6",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
           "inference_profile_id": "eu.anthropic.claude-sonnet-4-6"
         },
         "eu-west-3": {
-          "access_method": "both",
           "region": "eu-west-3",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
+          "regional_cris_profile_id": "eu.anthropic.claude-sonnet-4-6",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
           "inference_profile_id": "eu.anthropic.claude-sonnet-4-6"
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
+          "inference_profile_id": "global.anthropic.claude-sonnet-4-6"
         },
         "us-east-1": {
-          "access_method": "both",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
+          "regional_cris_profile_id": "us.anthropic.claude-sonnet-4-6",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-sonnet-4-6"
         },
         "us-east-2": {
-          "access_method": "both",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
+          "regional_cris_profile_id": "us.anthropic.claude-sonnet-4-6",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-sonnet-4-6"
         },
         "us-west-1": {
-          "access_method": "both",
           "region": "us-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
+          "regional_cris_profile_id": "us.anthropic.claude-sonnet-4-6",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-sonnet-4-6"
         },
         "us-west-2": {
-          "access_method": "both",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-sonnet-4-6",
+          "regional_cris_profile_id": "us.anthropic.claude-sonnet-4-6",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-6",
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-sonnet-4-6"
         }
       }
@@ -934,57 +1666,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -1004,69 +1781,124 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7-flash",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7-flash",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7-flash",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7-flash",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7-flash",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7-flash",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7-flash",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7-flash",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7-flash",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7-flash",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7-flash",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -1087,57 +1919,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-mini-3b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-mini-3b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-mini-3b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-mini-3b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-mini-3b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-mini-3b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-mini-3b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-mini-3b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-mini-3b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -1159,87 +2036,157 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "both",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-pro-v1:0",
+          "regional_cris_profile_id": "apac.amazon.nova-pro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.amazon.nova-pro-v1:0"
         },
         "ap-northeast-2": {
-          "access_method": "both",
           "region": "ap-northeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-pro-v1:0",
+          "regional_cris_profile_id": "apac.amazon.nova-pro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.amazon.nova-pro-v1:0"
         },
         "ap-south-1": {
-          "access_method": "both",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-pro-v1:0",
+          "regional_cris_profile_id": "apac.amazon.nova-pro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.amazon.nova-pro-v1:0"
         },
         "ap-southeast-1": {
-          "access_method": "both",
           "region": "ap-southeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-pro-v1:0",
+          "regional_cris_profile_id": "apac.amazon.nova-pro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.amazon.nova-pro-v1:0"
         },
         "ap-southeast-2": {
-          "access_method": "both",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-pro-v1:0",
+          "regional_cris_profile_id": "apac.amazon.nova-pro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.amazon.nova-pro-v1:0"
         },
         "eu-central-1": {
-          "access_method": "both",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-pro-v1:0",
+          "regional_cris_profile_id": "eu.amazon.nova-pro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.amazon.nova-pro-v1:0"
         },
         "eu-north-1": {
-          "access_method": "both",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-pro-v1:0",
+          "regional_cris_profile_id": "eu.amazon.nova-pro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.amazon.nova-pro-v1:0"
         },
         "eu-west-1": {
-          "access_method": "both",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-pro-v1:0",
+          "regional_cris_profile_id": "eu.amazon.nova-pro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.amazon.nova-pro-v1:0"
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-pro-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-3": {
-          "access_method": "both",
           "region": "eu-west-3",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-pro-v1:0",
+          "regional_cris_profile_id": "eu.amazon.nova-pro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.amazon.nova-pro-v1:0"
         },
         "us-east-1": {
-          "access_method": "both",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-pro-v1:0",
+          "regional_cris_profile_id": "us.amazon.nova-pro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.amazon.nova-pro-v1:0"
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-pro-v1:0",
-          "inference_profile_id": null
+          "regional_cris_profile_id": "us.amazon.nova-pro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
+          "inference_profile_id": "us.amazon.nova-pro-v1:0"
         },
         "us-west-1": {
-          "access_method": "both",
           "region": "us-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-pro-v1:0",
+          "regional_cris_profile_id": "us.amazon.nova-pro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.amazon.nova-pro-v1:0"
         },
         "us-west-2": {
-          "access_method": "both",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-pro-v1:0",
+          "regional_cris_profile_id": "us.amazon.nova-pro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.amazon.nova-pro-v1:0"
         }
       }
@@ -1260,21 +2207,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-remove-background-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-remove-background-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-remove-background-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-remove-background-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-remove-background-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-remove-background-v1:0"
         }
       }
@@ -1295,21 +2257,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-control-sketch-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-control-sketch-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-control-sketch-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-control-sketch-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-control-sketch-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-control-sketch-v1:0"
         }
       }
@@ -1331,63 +2308,168 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "cris_only",
           "region": "ap-northeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "jp.amazon.nova-2-lite-v1:0",
+          "global_cris_profile_id": "global.amazon.nova-2-lite-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "jp.amazon.nova-2-lite-v1:0"
         },
-        "ca-central-1": {
-          "access_method": "cris_only",
-          "region": "ca-central-1",
+        "ap-northeast-2": {
+          "region": "ap-northeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.amazon.nova-2-lite-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.amazon.nova-2-lite-v1:0"
+        },
+        "ap-south-1": {
+          "region": "ap-south-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.amazon.nova-2-lite-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.amazon.nova-2-lite-v1:0"
+        },
+        "ap-southeast-1": {
+          "region": "ap-southeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.amazon.nova-2-lite-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.amazon.nova-2-lite-v1:0"
+        },
+        "ap-southeast-2": {
+          "region": "ap-southeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.amazon.nova-2-lite-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.amazon.nova-2-lite-v1:0"
+        },
+        "ca-central-1": {
+          "region": "ca-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "us.amazon.nova-2-lite-v1:0",
+          "global_cris_profile_id": "global.amazon.nova-2-lite-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.amazon.nova-2-lite-v1:0"
         },
         "eu-central-1": {
-          "access_method": "cris_only",
           "region": "eu-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.amazon.nova-2-lite-v1:0",
+          "global_cris_profile_id": "global.amazon.nova-2-lite-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.amazon.nova-2-lite-v1:0"
         },
         "eu-north-1": {
-          "access_method": "cris_only",
           "region": "eu-north-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.amazon.nova-2-lite-v1:0",
+          "global_cris_profile_id": "global.amazon.nova-2-lite-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.amazon.nova-2-lite-v1:0"
         },
         "eu-west-1": {
-          "access_method": "cris_only",
           "region": "eu-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.amazon.nova-2-lite-v1:0",
+          "global_cris_profile_id": "global.amazon.nova-2-lite-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.amazon.nova-2-lite-v1:0"
         },
-        "eu-west-3": {
-          "access_method": "cris_only",
-          "region": "eu-west-3",
+        "eu-west-2": {
+          "region": "eu-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.amazon.nova-2-lite-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.amazon.nova-2-lite-v1:0"
+        },
+        "eu-west-3": {
+          "region": "eu-west-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "eu.amazon.nova-2-lite-v1:0",
+          "global_cris_profile_id": "global.amazon.nova-2-lite-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.amazon.nova-2-lite-v1:0"
         },
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.amazon.nova-2-lite-v1:0",
+          "global_cris_profile_id": "global.amazon.nova-2-lite-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.amazon.nova-2-lite-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.amazon.nova-2-lite-v1:0",
+          "global_cris_profile_id": "global.amazon.nova-2-lite-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.amazon.nova-2-lite-v1:0"
         },
         "us-west-1": {
-          "access_method": "cris_only",
           "region": "us-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.amazon.nova-2-lite-v1:0",
+          "global_cris_profile_id": "global.amazon.nova-2-lite-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.amazon.nova-2-lite-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.amazon.nova-2-lite-v1:0",
+          "global_cris_profile_id": "global.amazon.nova-2-lite-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.amazon.nova-2-lite-v1:0"
         }
       }
@@ -1408,21 +2490,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-conservative-upscale-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-conservative-upscale-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-conservative-upscale-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-conservative-upscale-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-conservative-upscale-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-conservative-upscale-v1:0"
         }
       }
@@ -1442,69 +2539,124 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -1525,57 +2677,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-12b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-12b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-12b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-12b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-12b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-12b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-12b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-12b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-12b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -1596,21 +2793,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-search-recolor-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-search-recolor-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-search-recolor-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-search-recolor-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-search-recolor-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-search-recolor-v1:0"
         }
       }
@@ -1630,45 +2842,80 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "moonshot.kimi-k2-thinking",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "moonshot.kimi-k2-thinking",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "moonshot.kimi-k2-thinking",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "moonshot.kimi-k2-thinking",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "moonshot.kimi-k2-thinking",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "moonshot.kimi-k2-thinking",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "moonshot.kimi-k2-thinking",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -1689,45 +2936,80 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-3-675b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-3-675b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-3-675b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-3-675b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-3-675b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-3-675b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-3-675b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -1748,105 +3030,190 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-northeast-2": {
-          "access_method": "direct",
           "region": "ap-northeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-northeast-3": {
-          "access_method": "direct",
           "region": "ap-northeast-3",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-1": {
-          "access_method": "direct",
           "region": "ap-southeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ca-central-1": {
-          "access_method": "direct",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-3": {
-          "access_method": "direct",
           "region": "eu-west-3",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-1": {
-          "access_method": "direct",
           "region": "us-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.pegasus-1-2-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -1867,27 +3234,47 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-2-sonic-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-2-sonic-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-2-sonic-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-2-sonic-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -1907,69 +3294,124 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.devstral-2-123b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.devstral-2-123b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.devstral-2-123b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.devstral-2-123b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.devstral-2-123b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.devstral-2-123b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.devstral-2-123b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.devstral-2-123b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.devstral-2-123b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.devstral-2-123b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.devstral-2-123b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -1989,69 +3431,124 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "minimax.minimax-m2.1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -2071,69 +3568,124 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-super-3-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-super-3-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-super-3-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-super-3-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-super-3-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-super-3-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-super-3-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-super-3-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-super-3-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-super-3-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-super-3-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -2153,69 +3705,124 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-32b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-32b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-32b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-32b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-32b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-32b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-32b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-32b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-32b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-32b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-32b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -2236,57 +3843,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-14b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-14b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-14b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-14b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-14b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-14b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-14b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-14b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-14b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -2307,105 +3959,190 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
+          "inference_profile_id": "global.anthropic.claude-opus-4-6-v1"
         },
         "ap-northeast-2": {
-          "access_method": "direct",
           "region": "ap-northeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
+          "inference_profile_id": "global.anthropic.claude-opus-4-6-v1"
         },
         "ap-northeast-3": {
-          "access_method": "direct",
           "region": "ap-northeast-3",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
+          "inference_profile_id": "global.anthropic.claude-opus-4-6-v1"
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
+          "inference_profile_id": "global.anthropic.claude-opus-4-6-v1"
         },
         "ap-southeast-1": {
-          "access_method": "direct",
           "region": "ap-southeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
+          "inference_profile_id": "global.anthropic.claude-opus-4-6-v1"
         },
         "ap-southeast-2": {
-          "access_method": "both",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
+          "regional_cris_profile_id": "au.anthropic.claude-opus-4-6-v1",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
           "inference_profile_id": "au.anthropic.claude-opus-4-6-v1"
         },
         "ca-central-1": {
-          "access_method": "both",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-6-v1",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-opus-4-6-v1"
         },
         "eu-central-1": {
-          "access_method": "both",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-6-v1",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
           "inference_profile_id": "eu.anthropic.claude-opus-4-6-v1"
         },
         "eu-north-1": {
-          "access_method": "both",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-6-v1",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
           "inference_profile_id": "eu.anthropic.claude-opus-4-6-v1"
         },
         "eu-west-1": {
-          "access_method": "both",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-6-v1",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
           "inference_profile_id": "eu.anthropic.claude-opus-4-6-v1"
         },
         "eu-west-2": {
-          "access_method": "both",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-6-v1",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
           "inference_profile_id": "eu.anthropic.claude-opus-4-6-v1"
         },
         "eu-west-3": {
-          "access_method": "both",
           "region": "eu-west-3",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-6-v1",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
           "inference_profile_id": "eu.anthropic.claude-opus-4-6-v1"
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
+          "inference_profile_id": "global.anthropic.claude-opus-4-6-v1"
         },
         "us-east-1": {
-          "access_method": "both",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-6-v1",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-opus-4-6-v1"
         },
         "us-east-2": {
-          "access_method": "both",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-6-v1",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-opus-4-6-v1"
         },
         "us-west-1": {
-          "access_method": "both",
           "region": "us-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-6-v1",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-opus-4-6-v1"
         },
         "us-west-2": {
-          "access_method": "both",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "anthropic.claude-opus-4-6-v1",
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-6-v1",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-6-v1",
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-opus-4-6-v1"
         }
       }
@@ -2425,57 +4162,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-9b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-9b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-9b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-9b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-9b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-9b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-9b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-9b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "nvidia.nemotron-nano-9b-v2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -2496,57 +4278,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-8b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-8b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-8b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-8b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-8b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-8b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-8b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-8b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-8b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -2567,57 +4394,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-small-24b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-small-24b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-small-24b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-small-24b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-small-24b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-small-24b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-small-24b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-small-24b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.voxtral-small-24b-2507",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -2637,57 +4509,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-5",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -2707,69 +4624,124 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-20b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-20b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-20b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-20b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-20b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-20b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-20b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-20b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-20b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-20b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-20b-1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -2790,57 +4762,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-4b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-4b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-4b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-4b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-4b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-4b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-4b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-4b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-4b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -2861,21 +4878,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-fast-upscale-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-fast-upscale-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-fast-upscale-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-fast-upscale-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-fast-upscale-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-fast-upscale-v1:0"
         }
       }
@@ -2896,75 +4928,190 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "cris_only",
           "region": "ap-northeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "jp.anthropic.claude-opus-4-8",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
           "inference_profile_id": "jp.anthropic.claude-opus-4-8"
+        },
+        "ap-northeast-2": {
+          "region": "ap-northeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-opus-4-8"
         },
         "ap-northeast-3": {
-          "access_method": "cris_only",
           "region": "ap-northeast-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "jp.anthropic.claude-opus-4-8",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
           "inference_profile_id": "jp.anthropic.claude-opus-4-8"
         },
-        "ap-southeast-2": {
-          "access_method": "cris_only",
-          "region": "ap-southeast-2",
+        "ap-south-1": {
+          "region": "ap-south-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-opus-4-8"
+        },
+        "ap-southeast-1": {
+          "region": "ap-southeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-opus-4-8"
+        },
+        "ap-southeast-2": {
+          "region": "ap-southeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "au.anthropic.claude-opus-4-8",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
           "inference_profile_id": "au.anthropic.claude-opus-4-8"
         },
         "ca-central-1": {
-          "access_method": "cris_only",
           "region": "ca-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-8",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-8"
         },
         "eu-central-1": {
-          "access_method": "cris_only",
           "region": "eu-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-8",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-opus-4-8"
         },
         "eu-north-1": {
-          "access_method": "cris_only",
           "region": "eu-north-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-8",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-opus-4-8"
         },
         "eu-west-1": {
-          "access_method": "cris_only",
           "region": "eu-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-8",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-opus-4-8"
         },
         "eu-west-2": {
-          "access_method": "cris_only",
           "region": "eu-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-8",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-opus-4-8"
         },
         "eu-west-3": {
-          "access_method": "cris_only",
           "region": "eu-west-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-8",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-opus-4-8"
         },
-        "us-east-1": {
-          "access_method": "cris_only",
-          "region": "us-east-1",
+        "sa-east-1": {
+          "region": "sa-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-opus-4-8"
+        },
+        "us-east-1": {
+          "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-8",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
+          "inference_profile_id": "us.anthropic.claude-opus-4-8"
+        },
+        "us-east-2": {
+          "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-8",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-8"
         },
         "us-west-1": {
-          "access_method": "cris_only",
           "region": "us-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-8",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-8"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-8",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-8",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-8"
         }
       }
@@ -2985,81 +5132,190 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "cris_only",
           "region": "ap-northeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "jp.anthropic.claude-opus-4-7",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
           "inference_profile_id": "jp.anthropic.claude-opus-4-7"
+        },
+        "ap-northeast-2": {
+          "region": "ap-northeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-opus-4-7"
         },
         "ap-northeast-3": {
-          "access_method": "cris_only",
           "region": "ap-northeast-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "jp.anthropic.claude-opus-4-7",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
           "inference_profile_id": "jp.anthropic.claude-opus-4-7"
         },
-        "ap-southeast-2": {
-          "access_method": "cris_only",
-          "region": "ap-southeast-2",
+        "ap-south-1": {
+          "region": "ap-south-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-opus-4-7"
+        },
+        "ap-southeast-1": {
+          "region": "ap-southeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-opus-4-7"
+        },
+        "ap-southeast-2": {
+          "region": "ap-southeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "au.anthropic.claude-opus-4-7",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
           "inference_profile_id": "au.anthropic.claude-opus-4-7"
         },
         "ca-central-1": {
-          "access_method": "cris_only",
           "region": "ca-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-7",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-7"
         },
         "eu-central-1": {
-          "access_method": "cris_only",
           "region": "eu-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-7",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-opus-4-7"
         },
         "eu-north-1": {
-          "access_method": "cris_only",
           "region": "eu-north-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-7",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-opus-4-7"
         },
         "eu-west-1": {
-          "access_method": "cris_only",
           "region": "eu-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-7",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-opus-4-7"
         },
         "eu-west-2": {
-          "access_method": "cris_only",
           "region": "eu-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-7",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-opus-4-7"
         },
         "eu-west-3": {
-          "access_method": "cris_only",
           "region": "eu-west-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-7",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-opus-4-7"
         },
-        "us-east-1": {
-          "access_method": "cris_only",
-          "region": "us-east-1",
+        "sa-east-1": {
+          "region": "sa-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-opus-4-7"
+        },
+        "us-east-1": {
+          "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-7",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-7"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-7",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-7"
         },
         "us-west-1": {
-          "access_method": "cris_only",
           "region": "us-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-7",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-7"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-7",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-7",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-7"
         }
       }
@@ -3080,21 +5336,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-erase-object-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-erase-object-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-erase-object-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-erase-object-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-erase-object-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-erase-object-v1:0"
         }
       }
@@ -3114,57 +5385,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-120b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -3185,57 +5501,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-27b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-27b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-27b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-27b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-27b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-27b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-27b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-27b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "google.gemma-3-27b-it",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -3256,21 +5617,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-control-structure-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-control-structure-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-control-structure-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-control-structure-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-control-structure-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-control-structure-v1:0"
         }
       }
@@ -3291,81 +5667,190 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "cris_only",
           "region": "ap-northeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "jp.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        },
+        "ap-northeast-2": {
+          "region": "ap-northeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
         },
         "ap-northeast-3": {
-          "access_method": "cris_only",
           "region": "ap-northeast-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "jp.anthropic.claude-sonnet-4-5-20250929-v1:0"
         },
-        "ap-southeast-2": {
-          "access_method": "cris_only",
-          "region": "ap-southeast-2",
+        "ap-south-1": {
+          "region": "ap-south-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        },
+        "ap-southeast-1": {
+          "region": "ap-southeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        },
+        "ap-southeast-2": {
+          "region": "ap-southeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "au.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "au.anthropic.claude-sonnet-4-5-20250929-v1:0"
         },
         "ca-central-1": {
-          "access_method": "cris_only",
           "region": "ca-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
         },
         "eu-central-1": {
-          "access_method": "cris_only",
           "region": "eu-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
         },
         "eu-north-1": {
-          "access_method": "cris_only",
           "region": "eu-north-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
         },
         "eu-west-1": {
-          "access_method": "cris_only",
           "region": "eu-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
         },
         "eu-west-2": {
-          "access_method": "cris_only",
           "region": "eu-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
         },
         "eu-west-3": {
-          "access_method": "cris_only",
           "region": "eu-west-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
         },
-        "us-east-1": {
-          "access_method": "cris_only",
-          "region": "us-east-1",
+        "sa-east-1": {
+          "region": "sa-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        },
+        "us-east-1": {
+          "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
         },
         "us-west-1": {
-          "access_method": "cris_only",
           "region": "us-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
         }
       }
@@ -3386,57 +5871,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-vl-235b-a22b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-vl-235b-a22b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-vl-235b-a22b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-vl-235b-a22b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-vl-235b-a22b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-vl-235b-a22b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-vl-235b-a22b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-vl-235b-a22b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-vl-235b-a22b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -3456,57 +5986,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "zai.glm-4.7",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -3527,21 +6102,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "writer.palmyra-vision-7b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "writer.palmyra-vision-7b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "writer.palmyra-vision-7b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -3562,21 +6152,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-outpaint-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-outpaint-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-outpaint-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-outpaint-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-outpaint-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-outpaint-v1:0"
         }
       }
@@ -3597,21 +6202,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-inpaint-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-inpaint-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-inpaint-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-inpaint-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-inpaint-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-inpaint-v1:0"
         }
       }
@@ -3632,21 +6252,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-1-20250805-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-1-20250805-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-1-20250805-v1:0"
         }
       }
@@ -3666,45 +6301,80 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-480b-a35b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-480b-a35b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-480b-a35b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-480b-a35b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-480b-a35b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-480b-a35b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-480b-a35b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -3725,21 +6395,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-style-guide-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-style-guide-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-style-guide-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-style-guide-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-style-guide-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-style-guide-v1:0"
         }
       }
@@ -3760,57 +6445,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.magistral-small-2509",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.magistral-small-2509",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.magistral-small-2509",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.magistral-small-2509",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.magistral-small-2509",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.magistral-small-2509",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.magistral-small-2509",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.magistral-small-2509",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.magistral-small-2509",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -3831,21 +6561,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-style-transfer-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-style-transfer-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-style-transfer-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-style-transfer-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-style-transfer-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-style-transfer-v1:0"
         }
       }
@@ -3866,105 +6611,190 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
+          "inference_profile_id": "global.cohere.embed-v4:0"
         },
         "ap-northeast-2": {
-          "access_method": "direct",
           "region": "ap-northeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
+          "inference_profile_id": "global.cohere.embed-v4:0"
         },
         "ap-northeast-3": {
-          "access_method": "direct",
           "region": "ap-northeast-3",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
+          "inference_profile_id": "global.cohere.embed-v4:0"
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
+          "inference_profile_id": "global.cohere.embed-v4:0"
         },
         "ap-southeast-1": {
-          "access_method": "direct",
           "region": "ap-southeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
+          "inference_profile_id": "global.cohere.embed-v4:0"
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
+          "inference_profile_id": "global.cohere.embed-v4:0"
         },
         "ca-central-1": {
-          "access_method": "direct",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
+          "inference_profile_id": "global.cohere.embed-v4:0"
         },
         "eu-central-1": {
-          "access_method": "both",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
+          "regional_cris_profile_id": "eu.cohere.embed-v4:0",
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
           "inference_profile_id": "eu.cohere.embed-v4:0"
         },
         "eu-north-1": {
-          "access_method": "both",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
+          "regional_cris_profile_id": "eu.cohere.embed-v4:0",
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
           "inference_profile_id": "eu.cohere.embed-v4:0"
         },
         "eu-west-1": {
-          "access_method": "both",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
+          "regional_cris_profile_id": "eu.cohere.embed-v4:0",
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
           "inference_profile_id": "eu.cohere.embed-v4:0"
         },
         "eu-west-2": {
-          "access_method": "both",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
+          "regional_cris_profile_id": "eu.cohere.embed-v4:0",
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
           "inference_profile_id": "eu.cohere.embed-v4:0"
         },
         "eu-west-3": {
-          "access_method": "both",
           "region": "eu-west-3",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
+          "regional_cris_profile_id": "eu.cohere.embed-v4:0",
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
           "inference_profile_id": "eu.cohere.embed-v4:0"
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
-          "inference_profile_id": null
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
+          "inference_profile_id": "global.cohere.embed-v4:0"
         },
         "us-east-1": {
-          "access_method": "both",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
+          "regional_cris_profile_id": "us.cohere.embed-v4:0",
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
           "inference_profile_id": "us.cohere.embed-v4:0"
         },
         "us-east-2": {
-          "access_method": "both",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
+          "regional_cris_profile_id": "us.cohere.embed-v4:0",
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
           "inference_profile_id": "us.cohere.embed-v4:0"
         },
         "us-west-1": {
-          "access_method": "both",
           "region": "us-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
+          "regional_cris_profile_id": "us.cohere.embed-v4:0",
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
           "inference_profile_id": "us.cohere.embed-v4:0"
         },
         "us-west-2": {
-          "access_method": "both",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": "cohere.embed-v4:0",
+          "regional_cris_profile_id": "us.cohere.embed-v4:0",
+          "global_cris_profile_id": "global.cohere.embed-v4:0",
+          "access_method": "both",
           "inference_profile_id": "us.cohere.embed-v4:0"
         }
       }
@@ -3984,45 +6814,80 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "deepseek.v3-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "deepseek.v3-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "deepseek.v3-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "deepseek.v3-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "deepseek.v3-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "deepseek.v3-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "deepseek.v3-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -4043,57 +6908,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-3b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-3b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-3b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-3b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-3b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-3b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-3b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-3b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.ministral-3-3b-instruct",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -4113,64 +7023,191 @@
       "inference_parameters_link": null,
       "hyperparameters_link": null,
       "region_access": {
-        "ca-central-1": {
-          "access_method": "cris_only",
-          "region": "ca-central-1",
+        "ap-northeast-1": {
+          "region": "ap-northeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0"
+        },
+        "ap-northeast-2": {
+          "region": "ap-northeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0"
+        },
+        "ap-northeast-3": {
+          "region": "ap-northeast-3",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0"
+        },
+        "ap-south-1": {
+          "region": "ap-south-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0"
+        },
+        "ap-southeast-1": {
+          "region": "ap-southeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0"
+        },
+        "ap-southeast-2": {
+          "region": "ap-southeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0"
+        },
+        "ca-central-1": {
+          "region": "ca-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-5-20251101-v1:0"
         },
         "eu-central-1": {
-          "access_method": "cris_only",
           "region": "eu-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-5-20251101-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-opus-4-5-20251101-v1:0"
         },
         "eu-north-1": {
-          "access_method": "cris_only",
           "region": "eu-north-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-5-20251101-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-opus-4-5-20251101-v1:0"
         },
         "eu-west-1": {
-          "access_method": "cris_only",
           "region": "eu-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-5-20251101-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-opus-4-5-20251101-v1:0"
         },
         "eu-west-2": {
-          "access_method": "cris_only",
           "region": "eu-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-5-20251101-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-opus-4-5-20251101-v1:0"
         },
         "eu-west-3": {
-          "access_method": "cris_only",
           "region": "eu-west-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-opus-4-5-20251101-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-opus-4-5-20251101-v1:0"
         },
-        "us-east-1": {
-          "access_method": "cris_only",
-          "region": "us-east-1",
+        "sa-east-1": {
+          "region": "sa-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0"
+        },
+        "us-east-1": {
+          "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-5-20251101-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-5-20251101-v1:0"
         },
         "us-west-1": {
-          "access_method": "cris_only",
           "region": "us-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-5-20251101-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
+          "global_cris_profile_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.anthropic.claude-opus-4-5-20251101-v1:0"
         }
       }
@@ -4191,21 +7228,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-search-replace-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-search-replace-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-search-replace-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-search-replace-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.stability.stable-image-search-replace-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.stability.stable-image-search-replace-v1:0"
         }
       }
@@ -4225,69 +7277,124 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-30b-a3b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-30b-a3b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-30b-a3b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-30b-a3b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-30b-a3b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-30b-a3b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-30b-a3b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-30b-a3b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-30b-a3b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-30b-a3b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-30b-a3b-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -4307,57 +7414,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-20b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-20b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-20b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-20b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-20b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-20b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-20b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-20b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "openai.gpt-oss-safeguard-20b",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -4379,21 +7531,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-premier-v1:0:8k",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-premier-v1:0:8k",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-premier-v1:0:8k",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -4415,21 +7582,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.amazon.nova-premier-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.amazon.nova-premier-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.amazon.nova-premier-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.amazon.nova-premier-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.amazon.nova-premier-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.amazon.nova-premier-v1:0"
         }
       }
@@ -4449,15 +7631,25 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-g1-text-02",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-g1-text-02",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -4479,93 +7671,168 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "both",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-lite-v1:0",
+          "regional_cris_profile_id": "apac.amazon.nova-lite-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.amazon.nova-lite-v1:0"
         },
         "ap-northeast-2": {
-          "access_method": "both",
           "region": "ap-northeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-lite-v1:0",
+          "regional_cris_profile_id": "apac.amazon.nova-lite-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.amazon.nova-lite-v1:0"
         },
         "ap-south-1": {
-          "access_method": "both",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-lite-v1:0",
+          "regional_cris_profile_id": "apac.amazon.nova-lite-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.amazon.nova-lite-v1:0"
         },
         "ap-southeast-1": {
-          "access_method": "both",
           "region": "ap-southeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-lite-v1:0",
+          "regional_cris_profile_id": "apac.amazon.nova-lite-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.amazon.nova-lite-v1:0"
         },
         "ap-southeast-2": {
-          "access_method": "both",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-lite-v1:0",
+          "regional_cris_profile_id": "apac.amazon.nova-lite-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.amazon.nova-lite-v1:0"
         },
         "ca-central-1": {
-          "access_method": "both",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-lite-v1:0",
+          "regional_cris_profile_id": "ca.amazon.nova-lite-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "ca.amazon.nova-lite-v1:0"
         },
         "eu-central-1": {
-          "access_method": "both",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-lite-v1:0",
+          "regional_cris_profile_id": "eu.amazon.nova-lite-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.amazon.nova-lite-v1:0"
         },
         "eu-north-1": {
-          "access_method": "both",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-lite-v1:0",
+          "regional_cris_profile_id": "eu.amazon.nova-lite-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.amazon.nova-lite-v1:0"
         },
         "eu-west-1": {
-          "access_method": "both",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-lite-v1:0",
+          "regional_cris_profile_id": "eu.amazon.nova-lite-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.amazon.nova-lite-v1:0"
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-lite-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-3": {
-          "access_method": "both",
           "region": "eu-west-3",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-lite-v1:0",
+          "regional_cris_profile_id": "eu.amazon.nova-lite-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.amazon.nova-lite-v1:0"
         },
         "us-east-1": {
-          "access_method": "both",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-lite-v1:0",
+          "regional_cris_profile_id": "us.amazon.nova-lite-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.amazon.nova-lite-v1:0"
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-lite-v1:0",
-          "inference_profile_id": null
+          "regional_cris_profile_id": "us.amazon.nova-lite-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
+          "inference_profile_id": "us.amazon.nova-lite-v1:0"
         },
         "us-west-1": {
-          "access_method": "both",
           "region": "us-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-lite-v1:0",
+          "regional_cris_profile_id": "us.amazon.nova-lite-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.amazon.nova-lite-v1:0"
         },
         "us-west-2": {
-          "access_method": "both",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-lite-v1:0",
+          "regional_cris_profile_id": "us.amazon.nova-lite-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.amazon.nova-lite-v1:0"
         }
       }
@@ -4585,81 +7852,146 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "both",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-micro-v1:0",
+          "regional_cris_profile_id": "apac.amazon.nova-micro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.amazon.nova-micro-v1:0"
         },
         "ap-northeast-2": {
-          "access_method": "both",
           "region": "ap-northeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-micro-v1:0",
+          "regional_cris_profile_id": "apac.amazon.nova-micro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.amazon.nova-micro-v1:0"
         },
         "ap-south-1": {
-          "access_method": "both",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-micro-v1:0",
+          "regional_cris_profile_id": "apac.amazon.nova-micro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.amazon.nova-micro-v1:0"
         },
         "ap-southeast-1": {
-          "access_method": "both",
           "region": "ap-southeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-micro-v1:0",
+          "regional_cris_profile_id": "apac.amazon.nova-micro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.amazon.nova-micro-v1:0"
         },
         "ap-southeast-2": {
-          "access_method": "both",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-micro-v1:0",
+          "regional_cris_profile_id": "apac.amazon.nova-micro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.amazon.nova-micro-v1:0"
         },
         "eu-central-1": {
-          "access_method": "both",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-micro-v1:0",
+          "regional_cris_profile_id": "eu.amazon.nova-micro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.amazon.nova-micro-v1:0"
         },
         "eu-north-1": {
-          "access_method": "both",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-micro-v1:0",
+          "regional_cris_profile_id": "eu.amazon.nova-micro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.amazon.nova-micro-v1:0"
         },
         "eu-west-1": {
-          "access_method": "both",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-micro-v1:0",
+          "regional_cris_profile_id": "eu.amazon.nova-micro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.amazon.nova-micro-v1:0"
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-micro-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-3": {
-          "access_method": "both",
           "region": "eu-west-3",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-micro-v1:0",
+          "regional_cris_profile_id": "eu.amazon.nova-micro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.amazon.nova-micro-v1:0"
         },
         "us-east-1": {
-          "access_method": "both",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-micro-v1:0",
+          "regional_cris_profile_id": "us.amazon.nova-micro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.amazon.nova-micro-v1:0"
         },
         "us-east-2": {
-          "access_method": "both",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-micro-v1:0",
+          "regional_cris_profile_id": "us.amazon.nova-micro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.amazon.nova-micro-v1:0"
         },
         "us-west-2": {
-          "access_method": "both",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "amazon.nova-micro-v1:0",
+          "regional_cris_profile_id": "us.amazon.nova-micro-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.amazon.nova-micro-v1:0"
         }
       }
@@ -4679,93 +8011,168 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-text-v1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-northeast-2": {
-          "access_method": "direct",
           "region": "ap-northeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-text-v1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-northeast-3": {
-          "access_method": "direct",
           "region": "ap-northeast-3",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-text-v1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-text-v1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-text-v1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ca-central-1": {
-          "access_method": "direct",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-text-v1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-text-v1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-north-1": {
-          "access_method": "direct",
           "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-text-v1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-text-v1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-text-v1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-3": {
-          "access_method": "direct",
           "region": "eu-west-3",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-text-v1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-text-v1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-text-v1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-2": {
-          "access_method": "direct",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-text-v1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-text-v1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -4786,63 +8193,113 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-image-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-image-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ca-central-1": {
-          "access_method": "direct",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-image-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-image-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-image-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-image-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-3": {
-          "access_method": "direct",
           "region": "eu-west-3",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-image-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-image-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-image-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-embed-image-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -4863,15 +8320,25 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-image-generator-v2:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.titan-image-generator-v2:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -4891,27 +8358,47 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.rerank-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ca-central-1": {
-          "access_method": "direct",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.rerank-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.rerank-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.rerank-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -4932,9 +8419,14 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "stability.sd3-5-large-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -4954,9 +8446,14 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "stability.stable-image-core-v1:1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -4976,9 +8473,14 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "stability.stable-image-ultra-v1:1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -4998,21 +8500,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "both",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-5-haiku-20241022-v1:0",
+          "regional_cris_profile_id": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-3-5-haiku-20241022-v1:0"
         },
         "us-east-2": {
-          "access_method": "both",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-5-haiku-20241022-v1:0",
+          "regional_cris_profile_id": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-3-5-haiku-20241022-v1:0"
         },
         "us-west-2": {
-          "access_method": "both",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-5-haiku-20241022-v1:0",
+          "regional_cris_profile_id": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-3-5-haiku-20241022-v1:0"
         }
       }
@@ -5033,81 +8550,146 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "both",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-sonnet-20240229-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.anthropic.claude-3-sonnet-20240229-v1:0"
         },
         "ap-northeast-2": {
-          "access_method": "both",
           "region": "ap-northeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-sonnet-20240229-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.anthropic.claude-3-sonnet-20240229-v1:0"
         },
         "ap-south-1": {
-          "access_method": "both",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-sonnet-20240229-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.anthropic.claude-3-sonnet-20240229-v1:0"
         },
         "ap-southeast-1": {
-          "access_method": "both",
           "region": "ap-southeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-sonnet-20240229-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.anthropic.claude-3-sonnet-20240229-v1:0"
         },
         "ap-southeast-2": {
-          "access_method": "both",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-sonnet-20240229-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.anthropic.claude-3-sonnet-20240229-v1:0"
         },
         "ca-central-1": {
-          "access_method": "direct",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "both",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
+          "regional_cris_profile_id": "eu.anthropic.claude-3-sonnet-20240229-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.anthropic.claude-3-sonnet-20240229-v1:0"
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-3": {
-          "access_method": "both",
           "region": "eu-west-3",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
+          "regional_cris_profile_id": "eu.anthropic.claude-3-sonnet-20240229-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.anthropic.claude-3-sonnet-20240229-v1:0"
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "both",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
+          "regional_cris_profile_id": "us.anthropic.claude-3-sonnet-20240229-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-3-sonnet-20240229-v1:0"
         },
         "us-west-2": {
-          "access_method": "both",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
+          "regional_cris_profile_id": "us.anthropic.claude-3-sonnet-20240229-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-3-sonnet-20240229-v1:0"
         },
         "eu-central-1": {
-          "access_method": "cris_only",
           "region": "eu-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "eu.anthropic.claude-3-sonnet-20240229-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "eu.anthropic.claude-3-sonnet-20240229-v1:0"
         }
       }
@@ -5128,87 +8710,157 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "both",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-haiku-20240307-v1:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-haiku-20240307-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.anthropic.claude-3-haiku-20240307-v1:0"
         },
         "ap-northeast-2": {
-          "access_method": "both",
           "region": "ap-northeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-haiku-20240307-v1:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-haiku-20240307-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.anthropic.claude-3-haiku-20240307-v1:0"
         },
         "ap-south-1": {
-          "access_method": "both",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-haiku-20240307-v1:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-haiku-20240307-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.anthropic.claude-3-haiku-20240307-v1:0"
         },
         "ap-southeast-1": {
-          "access_method": "both",
           "region": "ap-southeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-haiku-20240307-v1:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-haiku-20240307-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.anthropic.claude-3-haiku-20240307-v1:0"
         },
         "ap-southeast-2": {
-          "access_method": "both",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-haiku-20240307-v1:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-haiku-20240307-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "apac.anthropic.claude-3-haiku-20240307-v1:0"
         },
         "ca-central-1": {
-          "access_method": "direct",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-haiku-20240307-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "both",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-haiku-20240307-v1:0",
+          "regional_cris_profile_id": "eu.anthropic.claude-3-haiku-20240307-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.anthropic.claude-3-haiku-20240307-v1:0"
         },
         "eu-west-1": {
-          "access_method": "both",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-haiku-20240307-v1:0",
+          "regional_cris_profile_id": "eu.anthropic.claude-3-haiku-20240307-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.anthropic.claude-3-haiku-20240307-v1:0"
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-haiku-20240307-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-3": {
-          "access_method": "both",
           "region": "eu-west-3",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-haiku-20240307-v1:0",
+          "regional_cris_profile_id": "eu.anthropic.claude-3-haiku-20240307-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "eu.anthropic.claude-3-haiku-20240307-v1:0"
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-haiku-20240307-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "both",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-haiku-20240307-v1:0",
+          "regional_cris_profile_id": "us.anthropic.claude-3-haiku-20240307-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-3-haiku-20240307-v1:0"
         },
         "us-east-2": {
-          "access_method": "both",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-haiku-20240307-v1:0",
+          "regional_cris_profile_id": "us.anthropic.claude-3-haiku-20240307-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-3-haiku-20240307-v1:0"
         },
         "us-west-2": {
-          "access_method": "both",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "anthropic.claude-3-haiku-20240307-v1:0",
+          "regional_cris_profile_id": "us.anthropic.claude-3-haiku-20240307-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.anthropic.claude-3-haiku-20240307-v1:0"
         }
       }
@@ -5228,15 +8880,25 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.command-r-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.command-r-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -5256,15 +8918,25 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.command-r-plus-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.command-r-plus-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -5284,75 +8956,135 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-english-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-english-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-1": {
-          "access_method": "direct",
           "region": "ap-southeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-english-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-english-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ca-central-1": {
-          "access_method": "direct",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-english-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-english-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-english-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-english-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-3": {
-          "access_method": "direct",
           "region": "eu-west-3",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-english-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-english-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-english-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-english-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -5372,75 +9104,135 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-multilingual-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-multilingual-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-1": {
-          "access_method": "direct",
           "region": "ap-southeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-multilingual-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-multilingual-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ca-central-1": {
-          "access_method": "direct",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-multilingual-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-multilingual-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-multilingual-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-multilingual-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-3": {
-          "access_method": "direct",
           "region": "eu-west-3",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-multilingual-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-multilingual-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-multilingual-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.embed-multilingual-v3",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -5460,33 +9252,58 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.rerank-v3-5:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ca-central-1": {
-          "access_method": "direct",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.rerank-v3-5:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-central-1": {
-          "access_method": "direct",
           "region": "eu-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.rerank-v3-5:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.rerank-v3-5:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "cohere.rerank-v3-5:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -5506,33 +9323,58 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "meta.llama3-8b-instruct-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ca-central-1": {
-          "access_method": "direct",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "meta.llama3-8b-instruct-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "meta.llama3-8b-instruct-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "meta.llama3-8b-instruct-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "meta.llama3-8b-instruct-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -5552,33 +9394,58 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "meta.llama3-70b-instruct-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ca-central-1": {
-          "access_method": "direct",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "meta.llama3-70b-instruct-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "meta.llama3-70b-instruct-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "meta.llama3-70b-instruct-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "meta.llama3-70b-instruct-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -5598,21 +9465,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "both",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "meta.llama3-1-8b-instruct-v1:0",
+          "regional_cris_profile_id": "us.meta.llama3-1-8b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.meta.llama3-1-8b-instruct-v1:0"
         },
         "us-east-2": {
-          "access_method": "both",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "meta.llama3-1-8b-instruct-v1:0",
+          "regional_cris_profile_id": "us.meta.llama3-1-8b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.meta.llama3-1-8b-instruct-v1:0"
         },
         "us-west-2": {
-          "access_method": "both",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "meta.llama3-1-8b-instruct-v1:0",
+          "regional_cris_profile_id": "us.meta.llama3-1-8b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.meta.llama3-1-8b-instruct-v1:0"
         }
       }
@@ -5632,21 +9514,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "both",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "meta.llama3-1-70b-instruct-v1:0",
+          "regional_cris_profile_id": "us.meta.llama3-1-70b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.meta.llama3-1-70b-instruct-v1:0"
         },
         "us-east-2": {
-          "access_method": "both",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "meta.llama3-1-70b-instruct-v1:0",
+          "regional_cris_profile_id": "us.meta.llama3-1-70b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.meta.llama3-1-70b-instruct-v1:0"
         },
         "us-west-2": {
-          "access_method": "both",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "meta.llama3-1-70b-instruct-v1:0",
+          "regional_cris_profile_id": "us.meta.llama3-1-70b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.meta.llama3-1-70b-instruct-v1:0"
         }
       }
@@ -5666,15 +9563,25 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-2": {
-          "access_method": "both",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "meta.llama3-1-405b-instruct-v1:0",
+          "regional_cris_profile_id": "us.meta.llama3-1-405b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.meta.llama3-1-405b-instruct-v1:0"
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "meta.llama3-1-405b-instruct-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -5695,21 +9602,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama3-2-11b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama3-2-11b-instruct-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama3-2-11b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama3-2-11b-instruct-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama3-2-11b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama3-2-11b-instruct-v1:0"
         }
       }
@@ -5730,21 +9652,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama3-2-90b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama3-2-90b-instruct-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama3-2-90b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama3-2-90b-instruct-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama3-2-90b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama3-2-90b-instruct-v1:0"
         }
       }
@@ -5764,39 +9701,69 @@
       "hyperparameters_link": null,
       "region_access": {
         "eu-central-1": {
-          "access_method": "cris_only",
           "region": "eu-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "eu.meta.llama3-2-1b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "eu.meta.llama3-2-1b-instruct-v1:0"
         },
         "eu-west-1": {
-          "access_method": "cris_only",
           "region": "eu-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "eu.meta.llama3-2-1b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "eu.meta.llama3-2-1b-instruct-v1:0"
         },
         "eu-west-3": {
-          "access_method": "cris_only",
           "region": "eu-west-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "eu.meta.llama3-2-1b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "eu.meta.llama3-2-1b-instruct-v1:0"
         },
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama3-2-1b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama3-2-1b-instruct-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama3-2-1b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama3-2-1b-instruct-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama3-2-1b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama3-2-1b-instruct-v1:0"
         }
       }
@@ -5816,39 +9783,69 @@
       "hyperparameters_link": null,
       "region_access": {
         "eu-central-1": {
-          "access_method": "cris_only",
           "region": "eu-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "eu.meta.llama3-2-3b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "eu.meta.llama3-2-3b-instruct-v1:0"
         },
         "eu-west-1": {
-          "access_method": "cris_only",
           "region": "eu-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "eu.meta.llama3-2-3b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "eu.meta.llama3-2-3b-instruct-v1:0"
         },
         "eu-west-3": {
-          "access_method": "cris_only",
           "region": "eu-west-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "eu.meta.llama3-2-3b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "eu.meta.llama3-2-3b-instruct-v1:0"
         },
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama3-2-3b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama3-2-3b-instruct-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama3-2-3b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama3-2-3b-instruct-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama3-2-3b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama3-2-3b-instruct-v1:0"
         }
       }
@@ -5868,9 +9865,14 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "meta.llama3-3-70b-instruct-v1:0:128k",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -5890,21 +9892,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "both",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "meta.llama3-3-70b-instruct-v1:0",
+          "regional_cris_profile_id": "us.meta.llama3-3-70b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.meta.llama3-3-70b-instruct-v1:0"
         },
         "us-east-2": {
-          "access_method": "both",
           "region": "us-east-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "meta.llama3-3-70b-instruct-v1:0",
+          "regional_cris_profile_id": "us.meta.llama3-3-70b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.meta.llama3-3-70b-instruct-v1:0"
         },
         "us-west-2": {
-          "access_method": "both",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": "meta.llama3-3-70b-instruct-v1:0",
+          "regional_cris_profile_id": "us.meta.llama3-3-70b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
           "inference_profile_id": "us.meta.llama3-3-70b-instruct-v1:0"
         }
       }
@@ -5925,27 +9942,47 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama4-scout-17b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama4-scout-17b-instruct-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama4-scout-17b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama4-scout-17b-instruct-v1:0"
         },
         "us-west-1": {
-          "access_method": "cris_only",
           "region": "us-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama4-scout-17b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama4-scout-17b-instruct-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama4-scout-17b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama4-scout-17b-instruct-v1:0"
         }
       }
@@ -5966,27 +10003,47 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama4-maverick-17b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama4-maverick-17b-instruct-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama4-maverick-17b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama4-maverick-17b-instruct-v1:0"
         },
         "us-west-1": {
-          "access_method": "cris_only",
           "region": "us-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama4-maverick-17b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama4-maverick-17b-instruct-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.meta.llama4-maverick-17b-instruct-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.meta.llama4-maverick-17b-instruct-v1:0"
         }
       }
@@ -6006,57 +10063,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-7b-instruct-v0:2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-7b-instruct-v0:2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ca-central-1": {
-          "access_method": "direct",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-7b-instruct-v0:2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-7b-instruct-v0:2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-7b-instruct-v0:2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-3": {
-          "access_method": "direct",
           "region": "eu-west-3",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-7b-instruct-v0:2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-7b-instruct-v0:2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-7b-instruct-v0:2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-7b-instruct-v0:2",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -6076,57 +10178,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mixtral-8x7b-instruct-v0:1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mixtral-8x7b-instruct-v0:1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ca-central-1": {
-          "access_method": "direct",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mixtral-8x7b-instruct-v0:1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mixtral-8x7b-instruct-v0:1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mixtral-8x7b-instruct-v0:1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-3": {
-          "access_method": "direct",
           "region": "eu-west-3",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mixtral-8x7b-instruct-v0:1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mixtral-8x7b-instruct-v0:1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mixtral-8x7b-instruct-v0:1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mixtral-8x7b-instruct-v0:1",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -6146,57 +10293,102 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-south-1": {
-          "access_method": "direct",
           "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-2402-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-2402-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "ca-central-1": {
-          "access_method": "direct",
           "region": "ca-central-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-2402-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-2402-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-2402-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-3": {
-          "access_method": "direct",
           "region": "eu-west-3",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-2402-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "sa-east-1": {
-          "access_method": "direct",
           "region": "sa-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-2402-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-2402-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-2402-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -6216,9 +10408,14 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-large-2407-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -6239,45 +10436,80 @@
       "hyperparameters_link": null,
       "region_access": {
         "eu-central-1": {
-          "access_method": "cris_only",
           "region": "eu-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "eu.mistral.pixtral-large-2502-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "eu.mistral.pixtral-large-2502-v1:0"
         },
         "eu-north-1": {
-          "access_method": "cris_only",
           "region": "eu-north-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "eu.mistral.pixtral-large-2502-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "eu.mistral.pixtral-large-2502-v1:0"
         },
         "eu-west-1": {
-          "access_method": "cris_only",
           "region": "eu-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "eu.mistral.pixtral-large-2502-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "eu.mistral.pixtral-large-2502-v1:0"
         },
         "eu-west-3": {
-          "access_method": "cris_only",
           "region": "eu-west-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "eu.mistral.pixtral-large-2502-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "eu.mistral.pixtral-large-2502-v1:0"
         },
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.mistral.pixtral-large-2502-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.mistral.pixtral-large-2502-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.mistral.pixtral-large-2502-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.mistral.pixtral-large-2502-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.mistral.pixtral-large-2502-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.mistral.pixtral-large-2502-v1:0"
         }
       }
@@ -6297,9 +10529,14 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-west-2": {
-          "access_method": "direct",
           "region": "us-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "luma.ray-v2:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -6319,27 +10556,47 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.writer.palmyra-x4-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.writer.palmyra-x4-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.writer.palmyra-x4-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.writer.palmyra-x4-v1:0"
         },
         "us-west-1": {
-          "access_method": "cris_only",
           "region": "us-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.writer.palmyra-x4-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.writer.palmyra-x4-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.writer.palmyra-x4-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.writer.palmyra-x4-v1:0"
         }
       }
@@ -6359,28 +10616,280 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.writer.palmyra-x5-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.writer.palmyra-x5-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.writer.palmyra-x5-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.writer.palmyra-x5-v1:0"
         },
         "us-west-1": {
-          "access_method": "cris_only",
           "region": "us-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.writer.palmyra-x5-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.writer.palmyra-x5-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.writer.palmyra-x5-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.writer.palmyra-x5-v1:0"
+        }
+      }
+    },
+    "Claude 3 5 Sonnet 20240620": {
+      "model_name": "Claude 3 5 Sonnet 20240620",
+      "provider": "Anthropic",
+      "model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      "input_modalities": [
+        "IMAGE",
+        "TEXT"
+      ],
+      "output_modalities": [
+        "TEXT"
+      ],
+      "streaming_supported": true,
+      "inference_parameters_link": null,
+      "hyperparameters_link": null,
+      "region_access": {
+        "ap-northeast-1": {
+          "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
+          "model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
+          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0"
+        },
+        "ap-northeast-2": {
+          "region": "ap-northeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
+          "model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
+          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0"
+        },
+        "ap-south-1": {
+          "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
+          "model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
+          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0"
+        },
+        "ap-southeast-1": {
+          "region": "ap-southeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
+          "model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
+          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0"
+        },
+        "ap-southeast-2": {
+          "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
+          "model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
+          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0"
+        }
+      }
+    },
+    "Claude 3 5 Sonnet 20241022": {
+      "model_name": "Claude 3 5 Sonnet 20241022",
+      "provider": "Anthropic",
+      "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+      "input_modalities": [
+        "IMAGE",
+        "TEXT"
+      ],
+      "output_modalities": [
+        "TEXT"
+      ],
+      "streaming_supported": true,
+      "inference_parameters_link": null,
+      "hyperparameters_link": null,
+      "region_access": {
+        "ap-northeast-1": {
+          "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
+          "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
+          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
+        },
+        "ap-northeast-2": {
+          "region": "ap-northeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
+          "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
+          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
+        },
+        "ap-northeast-3": {
+          "region": "ap-northeast-3",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
+          "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
+          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
+        },
+        "ap-south-1": {
+          "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
+          "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
+          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
+        },
+        "ap-southeast-1": {
+          "region": "ap-southeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
+          "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
+          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
+        },
+        "ap-southeast-2": {
+          "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
+          "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
+          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
+        }
+      }
+    },
+    "Claude 3 7 Sonnet 20250219": {
+      "model_name": "Claude 3 7 Sonnet 20250219",
+      "provider": "Anthropic",
+      "model_id": "anthropic.claude-3-7-sonnet-20250219-v1:0",
+      "input_modalities": [
+        "IMAGE",
+        "TEXT"
+      ],
+      "output_modalities": [
+        "TEXT"
+      ],
+      "streaming_supported": true,
+      "inference_parameters_link": null,
+      "hyperparameters_link": null,
+      "region_access": {
+        "ap-south-1": {
+          "region": "ap-south-1",
+          "has_direct_access": true,
+          "has_regional_cris": true,
+          "has_global_cris": false,
+          "model_id": "anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "regional_cris_profile_id": "apac.anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "both",
+          "inference_profile_id": "apac.anthropic.claude-3-7-sonnet-20250219-v1:0"
+        },
+        "eu-west-2": {
+          "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
+          "model_id": "anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
+          "inference_profile_id": null
+        }
+      }
+    },
+    "Titan Embed Text V2:0": {
+      "model_name": "Titan Embed Text V2:0",
+      "provider": "Amazon",
+      "model_id": "amazon.titan-embed-text-v2:0:8k",
+      "input_modalities": [
+        "TEXT"
+      ],
+      "output_modalities": [
+        "EMBEDDING"
+      ],
+      "streaming_supported": false,
+      "inference_parameters_link": null,
+      "hyperparameters_link": null,
+      "region_access": {
+        "ap-northeast-3": {
+          "region": "ap-northeast-3",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
+          "model_id": "amazon.titan-embed-text-v2:0:8k",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
+          "inference_profile_id": null
+        },
+        "us-east-1": {
+          "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
+          "model_id": "amazon.titan-embed-text-v2:0:8k",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
+          "inference_profile_id": null
         }
       }
     },
@@ -6402,122 +10911,37 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-2": {
-          "access_method": "direct",
           "region": "ap-northeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.marengo-embed-3-0-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.marengo-embed-3-0-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "twelvelabs.marengo-embed-3-0-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
-        }
-      }
-    },
-    "Claude 3 5 Sonnet 20240620": {
-      "model_name": "Claude 3 5 Sonnet 20240620",
-      "provider": "Anthropic",
-      "model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-      "input_modalities": [
-        "IMAGE",
-        "TEXT"
-      ],
-      "output_modalities": [
-        "TEXT"
-      ],
-      "streaming_supported": true,
-      "inference_parameters_link": null,
-      "hyperparameters_link": null,
-      "region_access": {
-        "ap-northeast-1": {
-          "access_method": "both",
-          "region": "ap-northeast-1",
-          "model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0"
-        },
-        "ap-northeast-2": {
-          "access_method": "both",
-          "region": "ap-northeast-2",
-          "model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0"
-        },
-        "ap-south-1": {
-          "access_method": "both",
-          "region": "ap-south-1",
-          "model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0"
-        },
-        "ap-southeast-1": {
-          "access_method": "both",
-          "region": "ap-southeast-1",
-          "model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0"
-        },
-        "ap-southeast-2": {
-          "access_method": "both",
-          "region": "ap-southeast-2",
-          "model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0"
-        }
-      }
-    },
-    "Claude 3 5 Sonnet 20241022": {
-      "model_name": "Claude 3 5 Sonnet 20241022",
-      "provider": "Anthropic",
-      "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-      "input_modalities": [
-        "IMAGE",
-        "TEXT"
-      ],
-      "output_modalities": [
-        "TEXT"
-      ],
-      "streaming_supported": true,
-      "inference_parameters_link": null,
-      "hyperparameters_link": null,
-      "region_access": {
-        "ap-northeast-1": {
-          "access_method": "both",
-          "region": "ap-northeast-1",
-          "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
-        },
-        "ap-northeast-2": {
-          "access_method": "both",
-          "region": "ap-northeast-2",
-          "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
-        },
-        "ap-northeast-3": {
-          "access_method": "both",
-          "region": "ap-northeast-3",
-          "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
-        },
-        "ap-south-1": {
-          "access_method": "both",
-          "region": "ap-south-1",
-          "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
-        },
-        "ap-southeast-1": {
-          "access_method": "both",
-          "region": "ap-southeast-1",
-          "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
-        },
-        "ap-southeast-2": {
-          "access_method": "both",
-          "region": "ap-southeast-2",
-          "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-          "inference_profile_id": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
         }
       }
     },
@@ -6537,21 +10961,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-canvas-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-canvas-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-canvas-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -6572,21 +11011,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-1": {
-          "access_method": "direct",
           "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-reel-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-1": {
-          "access_method": "direct",
           "region": "eu-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-reel-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-reel-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -6606,182 +11060,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-southeast-2": {
-          "access_method": "direct",
           "region": "ap-southeast-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-next",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "eu-west-2": {
-          "access_method": "direct",
           "region": "eu-west-2",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-next",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         },
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "qwen.qwen3-coder-next",
-          "inference_profile_id": null
-        }
-      }
-    },
-    "Claude 3 7 Sonnet 20250219": {
-      "model_name": "Claude 3 7 Sonnet 20250219",
-      "provider": "Anthropic",
-      "model_id": "anthropic.claude-3-7-sonnet-20250219-v1:0",
-      "input_modalities": [
-        "IMAGE",
-        "TEXT"
-      ],
-      "output_modalities": [
-        "TEXT"
-      ],
-      "streaming_supported": true,
-      "inference_parameters_link": null,
-      "hyperparameters_link": null,
-      "region_access": {
-        "ap-south-1": {
-          "access_method": "both",
-          "region": "ap-south-1",
-          "model_id": "anthropic.claude-3-7-sonnet-20250219-v1:0",
-          "inference_profile_id": "apac.anthropic.claude-3-7-sonnet-20250219-v1:0"
-        },
-        "eu-west-2": {
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
           "access_method": "direct",
-          "region": "eu-west-2",
-          "model_id": "anthropic.claude-3-7-sonnet-20250219-v1:0",
-          "inference_profile_id": null
-        }
-      }
-    },
-    "Nova Sonic": {
-      "model_name": "Nova Sonic",
-      "provider": "Amazon",
-      "model_id": "amazon.nova-sonic-v1:0",
-      "input_modalities": [
-        "SPEECH"
-      ],
-      "output_modalities": [
-        "SPEECH",
-        "TEXT"
-      ],
-      "streaming_supported": true,
-      "inference_parameters_link": null,
-      "hyperparameters_link": null,
-      "region_access": {
-        "ap-northeast-1": {
-          "access_method": "direct",
-          "region": "ap-northeast-1",
-          "model_id": "amazon.nova-sonic-v1:0",
-          "inference_profile_id": null
-        },
-        "eu-north-1": {
-          "access_method": "direct",
-          "region": "eu-north-1",
-          "model_id": "amazon.nova-sonic-v1:0",
-          "inference_profile_id": null
-        },
-        "us-east-1": {
-          "access_method": "direct",
-          "region": "us-east-1",
-          "model_id": "amazon.nova-sonic-v1:0",
-          "inference_profile_id": null
-        }
-      }
-    },
-    "Claude Sonnet 4 20250514 V1:0": {
-      "model_name": "Claude Sonnet 4 20250514 V1:0",
-      "provider": "Anthropic",
-      "model_id": "anthropic.claude-sonnet-4-20250514-v1:0:32k",
-      "input_modalities": [
-        "IMAGE",
-        "TEXT"
-      ],
-      "output_modalities": [
-        "TEXT"
-      ],
-      "streaming_supported": true,
-      "inference_parameters_link": null,
-      "hyperparameters_link": null,
-      "region_access": {
-        "us-west-1": {
-          "access_method": "direct",
-          "region": "us-west-1",
-          "model_id": "anthropic.claude-sonnet-4-20250514-v1:0:32k",
-          "inference_profile_id": null
-        }
-      }
-    },
-    "Llama4 Scout 17b Instruct V1:0": {
-      "model_name": "Llama4 Scout 17b Instruct V1:0",
-      "provider": "Meta",
-      "model_id": "meta.llama4-scout-17b-instruct-v1:0:128k",
-      "input_modalities": [
-        "IMAGE",
-        "TEXT"
-      ],
-      "output_modalities": [
-        "TEXT"
-      ],
-      "streaming_supported": true,
-      "inference_parameters_link": null,
-      "hyperparameters_link": null,
-      "region_access": {
-        "us-west-1": {
-          "access_method": "direct",
-          "region": "us-west-1",
-          "model_id": "meta.llama4-scout-17b-instruct-v1:0:128k",
-          "inference_profile_id": null
-        }
-      }
-    },
-    "Llama4 Maverick 17b Instruct V1:0": {
-      "model_name": "Llama4 Maverick 17b Instruct V1:0",
-      "provider": "Meta",
-      "model_id": "meta.llama4-maverick-17b-instruct-v1:0:128k",
-      "input_modalities": [
-        "IMAGE",
-        "TEXT"
-      ],
-      "output_modalities": [
-        "TEXT"
-      ],
-      "streaming_supported": true,
-      "inference_parameters_link": null,
-      "hyperparameters_link": null,
-      "region_access": {
-        "us-west-1": {
-          "access_method": "direct",
-          "region": "us-west-1",
-          "model_id": "meta.llama4-maverick-17b-instruct-v1:0:128k",
-          "inference_profile_id": null
-        }
-      }
-    },
-    "Titan Embed Text V2:0": {
-      "model_name": "Titan Embed Text V2:0",
-      "provider": "Amazon",
-      "model_id": "amazon.titan-embed-text-v2:0:8k",
-      "input_modalities": [
-        "TEXT"
-      ],
-      "output_modalities": [
-        "EMBEDDING"
-      ],
-      "streaming_supported": false,
-      "inference_parameters_link": null,
-      "hyperparameters_link": null,
-      "region_access": {
-        "ap-northeast-3": {
-          "access_method": "direct",
-          "region": "ap-northeast-3",
-          "model_id": "amazon.titan-embed-text-v2:0:8k",
-          "inference_profile_id": null
-        },
-        "us-east-1": {
-          "access_method": "direct",
-          "region": "us-east-1",
-          "model_id": "amazon.titan-embed-text-v2:0:8k",
           "inference_profile_id": null
         }
       }
@@ -6804,9 +11112,64 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "amazon.nova-2-multimodal-embeddings-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
+          "inference_profile_id": null
+        }
+      }
+    },
+    "Nova Sonic": {
+      "model_name": "Nova Sonic",
+      "provider": "Amazon",
+      "model_id": "amazon.nova-sonic-v1:0",
+      "input_modalities": [
+        "SPEECH"
+      ],
+      "output_modalities": [
+        "SPEECH",
+        "TEXT"
+      ],
+      "streaming_supported": true,
+      "inference_parameters_link": null,
+      "hyperparameters_link": null,
+      "region_access": {
+        "ap-northeast-1": {
+          "region": "ap-northeast-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
+          "model_id": "amazon.nova-sonic-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
+          "inference_profile_id": null
+        },
+        "eu-north-1": {
+          "region": "eu-north-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
+          "model_id": "amazon.nova-sonic-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
+          "inference_profile_id": null
+        },
+        "us-east-1": {
+          "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
+          "model_id": "amazon.nova-sonic-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -6826,9 +11189,14 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "ai21.jamba-1-5-large-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -6848,9 +11216,14 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "ai21.jamba-1-5-mini-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -6870,9 +11243,98 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "direct",
           "region": "us-east-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
           "model_id": "mistral.mistral-small-2402-v1:0",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
+          "inference_profile_id": null
+        }
+      }
+    },
+    "Claude Sonnet 4 20250514 V1:0": {
+      "model_name": "Claude Sonnet 4 20250514 V1:0",
+      "provider": "Anthropic",
+      "model_id": "anthropic.claude-sonnet-4-20250514-v1:0:32k",
+      "input_modalities": [
+        "IMAGE",
+        "TEXT"
+      ],
+      "output_modalities": [
+        "TEXT"
+      ],
+      "streaming_supported": true,
+      "inference_parameters_link": null,
+      "hyperparameters_link": null,
+      "region_access": {
+        "us-west-1": {
+          "region": "us-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
+          "model_id": "anthropic.claude-sonnet-4-20250514-v1:0:32k",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
+          "inference_profile_id": null
+        }
+      }
+    },
+    "Llama4 Scout 17b Instruct V1:0": {
+      "model_name": "Llama4 Scout 17b Instruct V1:0",
+      "provider": "Meta",
+      "model_id": "meta.llama4-scout-17b-instruct-v1:0:128k",
+      "input_modalities": [
+        "IMAGE",
+        "TEXT"
+      ],
+      "output_modalities": [
+        "TEXT"
+      ],
+      "streaming_supported": true,
+      "inference_parameters_link": null,
+      "hyperparameters_link": null,
+      "region_access": {
+        "us-west-1": {
+          "region": "us-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
+          "model_id": "meta.llama4-scout-17b-instruct-v1:0:128k",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
+          "inference_profile_id": null
+        }
+      }
+    },
+    "Llama4 Maverick 17b Instruct V1:0": {
+      "model_name": "Llama4 Maverick 17b Instruct V1:0",
+      "provider": "Meta",
+      "model_id": "meta.llama4-maverick-17b-instruct-v1:0:128k",
+      "input_modalities": [
+        "IMAGE",
+        "TEXT"
+      ],
+      "output_modalities": [
+        "TEXT"
+      ],
+      "streaming_supported": true,
+      "inference_parameters_link": null,
+      "hyperparameters_link": null,
+      "region_access": {
+        "us-west-1": {
+          "region": "us-west-1",
+          "has_direct_access": true,
+          "has_regional_cris": false,
+          "has_global_cris": false,
+          "model_id": "meta.llama4-maverick-17b-instruct-v1:0:128k",
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": null,
+          "access_method": "direct",
           "inference_profile_id": null
         }
       }
@@ -6892,21 +11354,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.deepseek.r1-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.deepseek.r1-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.deepseek.r1-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.deepseek.r1-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.deepseek.r1-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.deepseek.r1-v1:0"
         }
       }
@@ -6925,64 +11402,191 @@
       "inference_parameters_link": null,
       "hyperparameters_link": null,
       "region_access": {
-        "ap-northeast-2": {
-          "access_method": "cris_only",
-          "region": "ap-northeast-2",
+        "ap-northeast-1": {
+          "region": "ap-northeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.twelvelabs.pegasus-1-2-v1:0"
+        },
+        "ap-northeast-2": {
+          "region": "ap-northeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "apac.twelvelabs.pegasus-1-2-v1:0",
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "apac.twelvelabs.pegasus-1-2-v1:0"
         },
-        "eu-central-1": {
-          "access_method": "cris_only",
-          "region": "eu-central-1",
+        "ap-northeast-3": {
+          "region": "ap-northeast-3",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.twelvelabs.pegasus-1-2-v1:0"
+        },
+        "ap-south-1": {
+          "region": "ap-south-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.twelvelabs.pegasus-1-2-v1:0"
+        },
+        "ap-southeast-1": {
+          "region": "ap-southeast-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.twelvelabs.pegasus-1-2-v1:0"
+        },
+        "ap-southeast-2": {
+          "region": "ap-southeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.twelvelabs.pegasus-1-2-v1:0"
+        },
+        "ca-central-1": {
+          "region": "ca-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.twelvelabs.pegasus-1-2-v1:0"
+        },
+        "eu-central-1": {
+          "region": "eu-central-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "eu.twelvelabs.pegasus-1-2-v1:0",
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.twelvelabs.pegasus-1-2-v1:0"
         },
         "eu-north-1": {
-          "access_method": "cris_only",
           "region": "eu-north-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.twelvelabs.pegasus-1-2-v1:0",
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.twelvelabs.pegasus-1-2-v1:0"
         },
         "eu-west-1": {
-          "access_method": "cris_only",
           "region": "eu-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.twelvelabs.pegasus-1-2-v1:0",
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.twelvelabs.pegasus-1-2-v1:0"
         },
         "eu-west-2": {
-          "access_method": "cris_only",
           "region": "eu-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.twelvelabs.pegasus-1-2-v1:0",
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.twelvelabs.pegasus-1-2-v1:0"
         },
         "eu-west-3": {
-          "access_method": "cris_only",
           "region": "eu-west-3",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "eu.twelvelabs.pegasus-1-2-v1:0",
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "eu.twelvelabs.pegasus-1-2-v1:0"
         },
-        "us-east-1": {
-          "access_method": "cris_only",
-          "region": "us-east-1",
+        "sa-east-1": {
+          "region": "sa-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": false,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": null,
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
+          "inference_profile_id": "global.twelvelabs.pegasus-1-2-v1:0"
+        },
+        "us-east-1": {
+          "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
+          "model_id": null,
+          "regional_cris_profile_id": "us.twelvelabs.pegasus-1-2-v1:0",
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.twelvelabs.pegasus-1-2-v1:0"
         },
         "us-east-2": {
-          "access_method": "cris_only",
           "region": "us-east-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.twelvelabs.pegasus-1-2-v1:0",
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.twelvelabs.pegasus-1-2-v1:0"
         },
         "us-west-1": {
-          "access_method": "cris_only",
           "region": "us-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.twelvelabs.pegasus-1-2-v1:0",
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.twelvelabs.pegasus-1-2-v1:0"
         },
         "us-west-2": {
-          "access_method": "cris_only",
           "region": "us-west-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": true,
           "model_id": null,
+          "regional_cris_profile_id": "us.twelvelabs.pegasus-1-2-v1:0",
+          "global_cris_profile_id": "global.twelvelabs.pegasus-1-2-v1:0",
+          "access_method": "cris_only",
           "inference_profile_id": "us.twelvelabs.pegasus-1-2-v1:0"
         }
       }
@@ -7002,21 +11606,36 @@
       "hyperparameters_link": null,
       "region_access": {
         "ap-northeast-2": {
-          "access_method": "cris_only",
           "region": "ap-northeast-2",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "apac.twelvelabs.marengo-embed-2-7-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "apac.twelvelabs.marengo-embed-2-7-v1:0"
         },
         "eu-west-1": {
-          "access_method": "cris_only",
           "region": "eu-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "eu.twelvelabs.marengo-embed-2-7-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "eu.twelvelabs.marengo-embed-2-7-v1:0"
         },
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.twelvelabs.marengo-embed-2-7-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.twelvelabs.marengo-embed-2-7-v1:0"
         }
       }
@@ -7036,15 +11655,25 @@
       "hyperparameters_link": null,
       "region_access": {
         "eu-west-1": {
-          "access_method": "cris_only",
           "region": "eu-west-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "eu.twelvelabs.marengo-embed-3-0-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "eu.twelvelabs.marengo-embed-3-0-v1:0"
         },
         "us-east-1": {
-          "access_method": "cris_only",
           "region": "us-east-1",
+          "has_direct_access": false,
+          "has_regional_cris": true,
+          "has_global_cris": false,
           "model_id": null,
+          "regional_cris_profile_id": "us.twelvelabs.marengo-embed-3-0-v1:0",
+          "global_cris_profile_id": null,
+          "access_method": "cris_only",
           "inference_profile_id": "us.twelvelabs.marengo-embed-3-0-v1:0"
         }
       }
@@ -7052,28 +11681,28 @@
   },
   "metadata": {
     "source": "bundled",
-    "retrieval_timestamp": "2026-06-17T18:01:01.348765",
+    "retrieval_timestamp": "2026-06-17T20:55:22.749659",
     "api_regions_queried": [
       "us-west-2",
-      "ap-northeast-2",
-      "us-east-2",
-      "eu-central-1",
-      "eu-west-1",
-      "eu-west-2",
       "ap-south-1",
+      "eu-central-1",
+      "us-east-2",
+      "ap-northeast-3",
+      "eu-west-1",
+      "us-east-1",
+      "eu-north-1",
+      "sa-east-1",
       "ap-southeast-2",
       "ap-northeast-1",
-      "ca-central-1",
-      "eu-north-1",
       "us-west-1",
-      "ap-southeast-1",
-      "ap-northeast-3",
-      "us-east-1",
+      "ap-northeast-2",
       "eu-west-3",
-      "sa-east-1"
+      "eu-west-2",
+      "ap-southeast-1",
+      "ca-central-1"
     ],
-    "bundled_data_version": "0.8.2",
+    "bundled_data_version": "0.8.3",
     "cache_file_path": null,
-    "generation_timestamp": "2026-06-17T18:01:01.348765"
+    "generation_timestamp": "2026-06-17T20:55:22.749659"
   }
 }

--- a/test/bestehorn_llmmanager/bedrock/catalog/test_api_fetcher_pagination.py
+++ b/test/bestehorn_llmmanager/bedrock/catalog/test_api_fetcher_pagination.py
@@ -1,0 +1,63 @@
+"""Tests for issue #21: _fetch_inference_profiles must paginate via nextToken.
+
+Regression context: the fetcher called list_inference_profiles once and returned only the
+first page. If a region returns more than one page of SYSTEM_DEFINED profiles, the later
+pages (which may include global.* profiles) were silently lost. The fix follows nextToken
+until exhausted and returns the union of all pages, while leaving the single-page case
+(no nextToken) byte-for-byte unchanged.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from bestehorn_llmmanager.bedrock.catalog.api_fetcher import BedrockAPIFetcher
+
+
+def _mock_auth_manager() -> MagicMock:
+    return MagicMock()
+
+
+class TestFetchInferenceProfilesPagination:
+    """P6 — multi-page responses are unioned; single-page unchanged."""
+
+    def test_paginates_across_multiple_pages(self) -> None:
+        auth = _mock_auth_manager()
+        client = MagicMock()
+        page1 = [{"inferenceProfileId": "us.anthropic.claude-opus-4-8"}]
+        page2 = [{"inferenceProfileId": "global.anthropic.claude-opus-4-8"}]
+        page3 = [{"inferenceProfileId": "eu.anthropic.claude-opus-4-8"}]
+        client.list_inference_profiles.side_effect = [
+            {"inferenceProfileSummaries": page1, "nextToken": "tok1"},
+            {"inferenceProfileSummaries": page2, "nextToken": "tok2"},
+            {"inferenceProfileSummaries": page3},  # no nextToken -> last page
+        ]
+        with patch.object(auth, "get_bedrock_control_client", return_value=client):
+            fetcher = BedrockAPIFetcher(auth_manager=auth)
+            result = fetcher._fetch_inference_profiles(region="us-east-1")
+
+        ids = [p["inferenceProfileId"] for p in result]
+        assert ids == [
+            "us.anthropic.claude-opus-4-8",
+            "global.anthropic.claude-opus-4-8",
+            "eu.anthropic.claude-opus-4-8",
+        ]
+        assert client.list_inference_profiles.call_count == 3
+        # First call must NOT carry a nextToken; later calls must pass the prior token.
+        first_call = client.list_inference_profiles.call_args_list[0]
+        assert "nextToken" not in first_call.kwargs
+        assert first_call.kwargs.get("typeEquals") == "SYSTEM_DEFINED"
+        assert client.list_inference_profiles.call_args_list[1].kwargs.get("nextToken") == "tok1"
+        assert client.list_inference_profiles.call_args_list[2].kwargs.get("nextToken") == "tok2"
+
+    def test_single_page_no_token_unchanged(self) -> None:
+        auth = _mock_auth_manager()
+        client = MagicMock()
+        client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [{"inferenceProfileId": "us.anthropic.claude-opus-4-8"}]
+        }
+        with patch.object(auth, "get_bedrock_control_client", return_value=client):
+            fetcher = BedrockAPIFetcher(auth_manager=auth)
+            result = fetcher._fetch_inference_profiles(region="us-east-1")
+
+        assert len(result) == 1
+        # Exactly one call, with the type filter and no nextToken (backward compatible).
+        client.list_inference_profiles.assert_called_once_with(typeEquals="SYSTEM_DEFINED")

--- a/test/bestehorn_llmmanager/bedrock/catalog/test_transformer.py
+++ b/test/bestehorn_llmmanager/bedrock/catalog/test_transformer.py
@@ -598,16 +598,27 @@ class TestCatalogTransformerExtractModelNameFromProfile:
     """Tests for _extract_model_name_from_profile method."""
 
     def test_extract_model_name_from_global_profile(self):
-        """Test extraction from global profile ID."""
+        """Global profile IDs map to the same (un-prefixed) name as their regional sibling.
+
+        Issue #21: the region/geo prefix (including 'global.') is stripped so that a model's
+        global and regional CRIS profiles group into ONE CRISModelInfo. The name must NOT
+        carry a 'Global ' prefix (that previously created a separate, un-correlatable model).
+        """
         transformer = CatalogTransformer()
 
         result = transformer._extract_model_name_from_profile(
             profile_id="global.anthropic.claude-3-5-haiku-20241022-v1:0"
         )
 
-        assert "Global" in result
+        assert "Global" not in result
         assert "Anthropic" in result
         assert "Claude" in result
+
+        # The global and regional profiles for the same model must produce the SAME name.
+        regional = transformer._extract_model_name_from_profile(
+            profile_id="us.anthropic.claude-3-5-haiku-20241022-v1:0"
+        )
+        assert result == regional
 
     def test_extract_model_name_from_regional_profile(self):
         """Test extraction from regional profile ID."""

--- a/test/bestehorn_llmmanager/bedrock/correlators/test_global_cris_end_to_end.py
+++ b/test/bestehorn_llmmanager/bedrock/correlators/test_global_cris_end_to_end.py
@@ -1,0 +1,92 @@
+"""End-to-end test for issue #21 + #16 CR-2: a correlated model carrying a global CRIS
+profile is selectable via AccessMethodSelector(caller_preference="global_cris").
+
+This ties the fix to its purpose: once the correlator retains the global profile
+(issue #21), the existing access-method selection (issue #16 CR-2) can actually resolve
+the global profile id instead of always falling back to regional/direct.
+"""
+
+from datetime import datetime
+
+from bestehorn_llmmanager.bedrock.correlators.model_cris_correlator import ModelCRISCorrelator
+from bestehorn_llmmanager.bedrock.models.cris_structures import (
+    CRISCatalog,
+    CRISInferenceProfile,
+    CRISModelInfo,
+)
+from bestehorn_llmmanager.bedrock.models.data_structures import BedrockModelInfo, ModelCatalog
+from bestehorn_llmmanager.bedrock.retry.access_method_selector import AccessMethodSelector
+from bestehorn_llmmanager.bedrock.retry.access_method_structures import (
+    AccessMethodNames,
+    AccessMethodPreference,
+)
+from bestehorn_llmmanager.bedrock.tracking.access_method_tracker import AccessMethodTracker
+
+REGIONAL_PROFILE = "us.anthropic.claude-opus-4-8"
+GLOBAL_PROFILE = "global.anthropic.claude-opus-4-8"
+
+
+def _correlated_region_access():
+    model = BedrockModelInfo(
+        provider="Anthropic",
+        model_id="anthropic.claude-opus-4-8",
+        regions_supported=["us-east-1*"],  # CRIS-only region
+        input_modalities=["Text"],
+        output_modalities=["Text"],
+        streaming_supported=True,
+        inference_parameters_link="https://example.com/params",
+        hyperparameters_link="https://example.com/hyper",
+    )
+    model_catalog = ModelCatalog(
+        retrieval_timestamp=datetime.now(), models={"Claude Opus 4 8": model}
+    )
+    cris_model = CRISModelInfo(
+        model_name="anthropic.claude-opus-4-8",
+        inference_profiles={
+            REGIONAL_PROFILE: CRISInferenceProfile(
+                inference_profile_id=REGIONAL_PROFILE,
+                region_mappings={"us-east-1": ["us-east-1", "us-west-2"]},
+                is_global=False,
+            ),
+            GLOBAL_PROFILE: CRISInferenceProfile(
+                inference_profile_id=GLOBAL_PROFILE,
+                region_mappings={"us-east-1": ["us-east-1", "eu-west-1"]},
+                is_global=True,
+            ),
+        },
+    )
+    cris_catalog = CRISCatalog(
+        retrieval_timestamp=datetime.now(),
+        cris_models={"anthropic.claude-opus-4-8": cris_model},
+    )
+    result = ModelCRISCorrelator(enable_fuzzy_matching=False).correlate_catalogs(
+        model_catalog=model_catalog, cris_catalog=cris_catalog
+    )
+    unified = next(iter(result.unified_models.values()))
+    return unified.region_access
+
+
+class TestGlobalCrisSelectableEndToEnd:
+    """P5 — caller_preference='global_cris' resolves the global id for a correlated model."""
+
+    def test_selector_resolves_global_profile_from_correlated_catalog(self) -> None:
+        access = _correlated_region_access()
+        info = access["us-east-1"]
+        # Precondition (issue #21 fix): the correlated model carries the global profile.
+        assert info.has_global_cris is True
+        assert info.global_cris_profile_id == GLOBAL_PROFILE
+
+        selector = AccessMethodSelector(access_method_tracker=AccessMethodTracker.get_instance())
+        caller = AccessMethodPreference.from_method_name(AccessMethodNames.GLOBAL_CRIS)
+        model_id, method = selector.select_access_method(access_info=info, caller_preference=caller)
+        assert method == AccessMethodNames.GLOBAL_CRIS
+        assert model_id == GLOBAL_PROFILE
+
+    def test_default_selection_still_prefers_regional_when_no_preference(self) -> None:
+        """Backward-compat: with no caller preference, default order is unchanged."""
+        access = _correlated_region_access()
+        info = access["us-east-1"]
+        selector = AccessMethodSelector(access_method_tracker=AccessMethodTracker.get_instance())
+        _model_id, method = selector.select_access_method(access_info=info)
+        # No direct access on this CRIS-only region; default order picks regional CRIS.
+        assert method == AccessMethodNames.REGIONAL_CRIS

--- a/test/bestehorn_llmmanager/bedrock/correlators/test_model_cris_correlator_global.py
+++ b/test/bestehorn_llmmanager/bedrock/correlators/test_model_cris_correlator_global.py
@@ -1,0 +1,136 @@
+"""Tests for issue #21: the correlator must retain global.* CRIS profiles.
+
+Regression context: a region served by BOTH a regional CRIS profile (us./eu./jp./au.) and
+a global CRIS profile (global.*) previously kept only the regional one — the correlator
+took profiles[0] from get_profiles_for_source_region and discarded the rest, so
+has_global_cris was never set for any model that also had a regional profile. This made
+issue #16's CR-2 (access_method_preference="global_cris") unusable: no catalog model ever
+carried a global_cris_profile_id.
+
+These tests assert that a region with both profile kinds records BOTH on its
+ModelAccessInfo, that a global-only region sets has_global_cris, and that regional-only
+behavior is unchanged.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from bestehorn_llmmanager.bedrock.correlators.model_cris_correlator import ModelCRISCorrelator
+from bestehorn_llmmanager.bedrock.models.cris_structures import (
+    CRISCatalog,
+    CRISInferenceProfile,
+    CRISModelInfo,
+)
+from bestehorn_llmmanager.bedrock.models.data_structures import BedrockModelInfo, ModelCatalog
+
+MODEL_ID = "anthropic.claude-opus-4-8"
+REGIONAL_PROFILE = "us.anthropic.claude-opus-4-8"
+GLOBAL_PROFILE = "global.anthropic.claude-opus-4-8"
+
+
+@pytest.fixture
+def correlator() -> ModelCRISCorrelator:
+    return ModelCRISCorrelator(enable_fuzzy_matching=False)
+
+
+def _model_catalog(regions) -> ModelCatalog:
+    """A bedrock model marked CRIS-only (regions suffixed with *) so access comes from
+    inference profiles, mirroring how Opus 4.8 appears in the real catalog."""
+    model = BedrockModelInfo(
+        provider="Anthropic",
+        model_id=MODEL_ID,
+        regions_supported=[f"{r}*" for r in regions],  # '*' marks CRIS-only regions
+        input_modalities=["Text"],
+        output_modalities=["Text"],
+        streaming_supported=True,
+        inference_parameters_link="https://example.com/params",
+        hyperparameters_link="https://example.com/hyper",
+    )
+    return ModelCatalog(retrieval_timestamp=datetime.now(), models={"Claude Opus 4 8": model})
+
+
+def _cris_catalog(profiles) -> CRISCatalog:
+    cris_model = CRISModelInfo(
+        model_name="anthropic.claude-opus-4-8",
+        inference_profiles={p.inference_profile_id: p for p in profiles},
+    )
+    return CRISCatalog(
+        retrieval_timestamp=datetime.now(),
+        cris_models={"anthropic.claude-opus-4-8": cris_model},
+    )
+
+
+def _region_access(correlator, regions, profiles):
+    result = correlator.correlate_catalogs(
+        model_catalog=_model_catalog(regions),
+        cris_catalog=_cris_catalog(profiles),
+    )
+    # The correlator keys the unified model by a normalized name; this test exercises a
+    # single model, so fetch it without assuming the exact key.
+    assert (
+        len(result.unified_models) == 1
+    ), f"expected 1 unified model, got {list(result.unified_models)}"
+    unified = next(iter(result.unified_models.values()))
+    return unified.region_access
+
+
+class TestRegionWithRegionalAndGlobal:
+    """P1 — a region covered by both regional and global profiles records BOTH."""
+
+    def test_region_has_both_regional_and_global_cris(self, correlator) -> None:
+        regional = CRISInferenceProfile(
+            inference_profile_id=REGIONAL_PROFILE,
+            region_mappings={"us-east-1": ["us-east-1", "us-west-2"]},
+            is_global=False,
+        )
+        glob = CRISInferenceProfile(
+            inference_profile_id=GLOBAL_PROFILE,
+            region_mappings={"us-east-1": ["us-east-1", "eu-west-1", "ap-south-1"]},
+            is_global=True,
+        )
+        access = _region_access(correlator, ["us-east-1"], [regional, glob])
+
+        assert "us-east-1" in access
+        info = access["us-east-1"]
+        assert info.has_regional_cris is True, "regional CRIS must be retained"
+        assert info.regional_cris_profile_id == REGIONAL_PROFILE
+        assert info.has_global_cris is True, "global CRIS must also be recorded (issue #21)"
+        assert info.global_cris_profile_id == GLOBAL_PROFILE
+
+
+class TestGlobalOnlyRegion:
+    """P2 — a region covered only by a global profile sets has_global_cris."""
+
+    def test_global_only_region(self, correlator) -> None:
+        glob = CRISInferenceProfile(
+            inference_profile_id=GLOBAL_PROFILE,
+            region_mappings={"eu-west-1": ["eu-west-1", "us-east-1"]},
+            is_global=True,
+        )
+        access = _region_access(correlator, ["eu-west-1"], [glob])
+
+        assert "eu-west-1" in access
+        info = access["eu-west-1"]
+        assert info.has_global_cris is True
+        assert info.global_cris_profile_id == GLOBAL_PROFILE
+        assert info.has_regional_cris is False
+
+
+class TestRegionalOnlyUnchanged:
+    """P3 — a region covered only by a regional profile is unchanged (no global flag)."""
+
+    def test_regional_only_region(self, correlator) -> None:
+        regional = CRISInferenceProfile(
+            inference_profile_id=REGIONAL_PROFILE,
+            region_mappings={"us-east-1": ["us-east-1", "us-west-2"]},
+            is_global=False,
+        )
+        access = _region_access(correlator, ["us-east-1"], [regional])
+
+        assert "us-east-1" in access
+        info = access["us-east-1"]
+        assert info.has_regional_cris is True
+        assert info.regional_cris_profile_id == REGIONAL_PROFILE
+        assert info.has_global_cris is False
+        assert info.global_cris_profile_id is None


### PR DESCRIPTION
## Summary

Fixes #21: the catalog pipeline silently dropped **every** `global.*` cross-region inference profile, so no model ever exposed `has_global_cris` and issue #16's CR-2 (`access_method_preference="global_cris"`) could never resolve a global profile.

**Root cause (upstream of the correlator, contrary to the issue's initial guess):** a global profile's model ARN is region-less (`arn:aws:bedrock:::foundation-model/…`). The transformer recorded an empty destination region → `CRISInferenceProfile` validation rejected it → the global profile was dropped *before correlation*. Separately, a `"Global "`-prefixed CRIS model name prevented correlation onto the base model (and an earlier global-priority match would have *replaced* regional with global).

## Fix (all four needed; verified end-to-end against live AWS data)

- **transformer `_build_region_mappings_from_models`** — skip empty-region ARN components so a global profile survives extraction (falls back to `{source_region: [source_region]}`).
- **transformer `_extract_model_name_from_profile`** — stop prefixing global profiles with `"Global "`, so a model's global and regional CRIS profiles group into ONE `CRISModelInfo`.
- **correlator `_merge_all_cris_profiles_per_region` / `_split_region_profiles`** — reconcile each region to carry **both** regional (geographic) and global CRIS when both route from it, instead of keeping only the first. Per AWS docs, geographic vs global are distinct, caller-selectable profiles (data residency vs cost/throughput).
- **`api_fetcher._fetch_inference_profiles`** — paginate via `nextToken` (latent loss otherwise).
- **serialization** (`unified_structures` `to_dict`/`from_dict` + orthogonal `UnifiedJSONFields`) — write/read `has_direct_access` / `has_regional_cris` / `has_global_cris` + their profile ids so a region can carry both; legacy `access_method`/`inference_profile_id` still written and read for backward compatibility with old caches.

## Proof

Regenerated bundled catalog (live data, `insights-analytics-prod`): **`Claude Opus 4 8` now has 17 regions with global CRIS and 13 with regional CRIS (13 with BOTH)** — previously 13 regional / **0 global**. All 12 `global.*` profiles are now retained. **No regional access lost** (an earlier global-priority approach regressed that; this does not). Serialization round-trips both profiles.

- New tests: correlator-global (regional+global / global-only / regional-only), api-fetcher pagination, end-to-end selection (`caller_preference="global_cris"` resolves the global id from a correlated model).
- Updated the one transformer test that encoded the old `"Global "` naming (it asserted the bug).
- **Full suite: 2618 passed, 7 skipped, 0 failed.** black / isort / flake8 / mypy clean.

## Notes
- The bundled `bedrock_catalog_bundled.json` is regenerated in this PR so the shipped fallback data now includes global profiles.
- Unblocks issue #16's CR-2 in production (global CRIS is now a real, selectable target).

Closes #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
