### PR TITLE
ci: bump GitHub Actions to Node 24 runtimes and CodeQL v4 (#18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     
@@ -44,10 +44,10 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     
@@ -62,7 +62,7 @@ jobs:
     
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.11'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
@@ -73,10 +73,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     
@@ -97,7 +97,7 @@ jobs:
         ls -la dist/
     
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: dist-packages
         path: dist/
@@ -109,15 +109,15 @@ jobs:
       
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: python
     
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
     
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Required for setuptools-scm to access git history and tags
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     
@@ -33,7 +33,7 @@ jobs:
     
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.11'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
@@ -50,12 +50,12 @@ jobs:
       contents: write
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Required for setuptools-scm to access git history and tags
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     


### PR DESCRIPTION
## Summary

Clears the recurring **"Node.js 20 is deprecated"** warnings on every CI job and the upcoming **CodeQL Action v3** deprecation (Dec 2026) by bumping each pinned GitHub Action to a major that runs natively on Node 24.

Closes #18.

## Changes (`.github/workflows/ci.yml` and `release.yml`)

| Action | Was | Now |
| --- | --- | --- |
| `actions/checkout` | v4 | **v6** |
| `actions/setup-python` | v5 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |
| `codecov/codecov-action` | v4 | **v7** |
| `github/codeql-action/{init,autobuild,analyze}` | v3 | **v4** |

`pypa/gh-action-pypi-publish` is a Docker action (no Node runtime) and is intentionally left as-is. Target majors were verified current against each action's release page (all run on Node 24).

## Verification
- Both workflow files validated as well-formed YAML.
- The real proof is this PR's own CI run: all jobs (lint, build, security/CodeQL, test matrix 3.10–3.14) pass on the new action versions, with no Node 20 deprecation warnings and no CodeQL v3 warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
