### PR TITLE
ci: parallelize the unit-test suite with pytest-xdist (#19)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,15 @@
 [run]
 source = src/bestehorn_llmmanager
-omit = 
+# Issue #19: tests run under pytest-xdist (-n auto); its workers are separate processes.
+# parallel=true with the multiprocessing concurrency model makes coverage write per-process
+# data files that combine into the full total. Without this, worker coverage is
+# under-counted under xdist (markedly so on Windows).
+parallel = true
+concurrency =
+    multiprocessing
+    thread
+sigterm = true
+omit =
     */tests/*
     */test_*
     */__pycache__/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,24 +42,31 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-    
+
     steps:
     - uses: actions/checkout@v6
-    
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
-    
-    - name: Run unit tests
+
+    - name: Run unit tests (parallel with pytest-xdist)
+      # -n auto distributes the suite across the runner's CPU cores (issue #19). The
+      # coverage [run] parallel/concurrency config in .coveragerc lets the xdist workers'
+      # coverage data combine into the full total, so the 80% gate is enforced on the
+      # complete run. Integration tests stay excluded (they require live AWS).
       run: |
-        pytest test/bestehorn_llmmanager/ -v --cov=bestehorn_llmmanager --cov-report=xml --ignore=test/integration/
-    
+        pytest test/bestehorn_llmmanager/ \
+          -n auto \
+          --cov=bestehorn_llmmanager --cov-report=xml \
+          --ignore=test/integration/
+
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.11'
       uses: codecov/codecov-action@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,12 @@ Run tests:
 # Run all tests
 pytest
 
+# Run in parallel across CPU cores (much faster; this is what CI does)
+pytest -n auto
+
+# Run serially — use this when debugging a failure (clearer output, no worker noise)
+pytest -n0
+
 # Run with coverage
 pytest --cov=bestehorn_llmmanager
 
@@ -104,6 +110,11 @@ pytest -m "not integration"
 # Run specific test file
 pytest test/bestehorn_llmmanager/test_llm_manager.py
 ```
+
+The test suite is parallel-safe and CI runs it with `pytest -n auto` (pytest-xdist).
+Coverage is collected correctly under parallel execution via the `parallel`/`concurrency`
+settings in `.coveragerc`. Drop to `-n0` for serial execution when a failure is easier to
+read without xdist workers.
 
 ### Documentation
 


### PR DESCRIPTION
Closes #19.

## What

Run the CI unit-test matrix under `pytest -n auto` instead of serially, so each Python-version job distributes the suite across the runner's CPU cores.

## Changes

- **`.github/workflows/ci.yml`** — the `test` job now runs `pytest test/bestehorn_llmmanager/ -n auto --cov=bestehorn_llmmanager --cov-report=xml --ignore=test/integration/`. No cross-runner shard axis: each `python-version` matrix entry parallelizes internally, and the 80% coverage gate is enforced on that single per-version run.
- **`.coveragerc`** — added `parallel = true` and `concurrency = multiprocessing thread` so the xdist workers' per-process coverage data combines into the full total. Without this, worker coverage is under-counted under xdist.
- **`CONTRIBUTING.md`** — documents `pytest -n auto` as the canonical local invocation and `pytest -n0` as the serial fallback for debugging.

## Design note (why no pytest-split sharding)

The issue floated cross-runner sharding (pytest-split) as an option. I dropped it: it would stack a second fragile coverage-merge layer on top of xdist's, for marginal wall-clock benefit on a suite this size. `-n auto` per matrix entry is the simpler, robust win. See the decision log (DL-002).

## Proof

- Suite is parallel-safe: full suite passes under `-n auto` with zero failures (verified earlier this session: 2620 passed).
- Coverage combines correctly under the new `.coveragerc` config — this PR's CI run on Linux is the authoritative check (the local Windows full-suite coverage figure under xdist is a known environment artifact noted in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)