### PR TITLE
fix(catalog): retry throttled model/profile discovery with jittered backoff (#30)

### DIFF
--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -33,3 +33,24 @@ Entry format:
   (`ruff format` + `ruff check`, with ruff's `S` rules replacing bandit) under issue
   #15; the tool names above have been updated to reflect the migration. The underlying
   lessons (line-length 100, exclude `_version.py` everywhere) are unchanged.
+
+## 2026-06-20 — A class-level tenacity @retry decorator ignores per-instance config (issue #30)
+- **Context**: Fixing throttled control-plane discovery (`list_foundation_models` /
+  `list_inference_profiles`) in `bedrock/catalog/api_fetcher.py` so a fan-out
+  cold-start retries instead of failing fast.
+- **Lesson**: Two non-obvious traps. (1) The `@retry(...)` decorator bound
+  `stop_after_attempt(CatalogDefaults.DEFAULT_MAX_RETRIES)` at **class-definition
+  time**, so `BedrockAPIFetcher.__init__(max_retries=...)` was a **dead argument** — the
+  budget could never be configured per instance. (2) The `except ClientError` body
+  re-raised `ThrottlingException` **wrapped** as `APIFetchError`, but the retry predicate
+  was `retry_if_exception_type((ClientError, BotoCoreError))` — `APIFetchError` matches
+  neither, so the wrap silently **defeated the very retry it was meant to feed**, and a
+  throttle failed immediately. Plain `wait_exponential` (no jitter) also makes a
+  synchronized fleet retry in lockstep and re-collide.
+- **Action**: Replace the static decorator with a per-call instance controller
+  (`self._build_retrying()` → `tenacity.Retrying`) built from `self._max_retries`, so the
+  budget is honored and configurable; add a retryable `APIThrottleError(APIFetchError)`
+  and put it in the predicate (`(ClientError, BotoCoreError, APIThrottleError)`) so
+  `ThrottlingException` retries while `AccessDeniedException` stays fast-fail; use
+  `wait_exponential_jitter` to de-correlate the herd. When you see a tenacity `@retry`
+  whose `wait`/`stop` reference instance config, suspect the dead-decorator trap.

--- a/src/bestehorn_llmmanager/bedrock/catalog/api_fetcher.py
+++ b/src/bestehorn_llmmanager/bedrock/catalog/api_fetcher.py
@@ -11,10 +11,15 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional, Tuple
 
 from botocore.exceptions import BotoCoreError, ClientError
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+from tenacity import (
+    Retrying,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
 
 from ..auth.auth_manager import AuthManager
-from ..exceptions.llm_manager_exceptions import APIFetchError
+from ..exceptions.llm_manager_exceptions import APIFetchError, APIThrottleError
 from ..models.aws_regions import get_commercial_regions
 from ..models.catalog_constants import (
     CatalogAPIParameters,
@@ -120,6 +125,38 @@ class BedrockAPIFetcher:
         self._logger.debug(
             f"BedrockAPIFetcher initialized: timeout={timeout}s, "
             f"max_workers={max_workers}, max_retries={max_retries}"
+        )
+
+    def _build_retrying(self) -> Retrying:
+        """
+        Build a tenacity retry controller for a single discovery API call.
+
+        The controller is built per call from instance state so the configured
+        ``max_retries`` is actually honored (issue #30 — previously the retry budget was
+        hardcoded at class-definition time via a ``@retry`` decorator, leaving the
+        constructor argument dead). It:
+
+        - retries transient control-plane failures: ``ClientError``/``BotoCoreError`` and
+          the retryable ``APIThrottleError`` (raised for ``ThrottlingException``), while a
+          non-retryable ``APIFetchError`` (e.g. ``AccessDeniedException``) is NOT matched
+          and so fails fast;
+        - waits with **jittered** exponential backoff (``wait_exponential_jitter``) so a
+          synchronized fleet of cold-starting workers does not retry in lockstep and
+          re-collide on the throttled discovery API;
+        - reraises the final exception (so the caller sees the real error, not a
+          ``RetryError`` wrapper).
+
+        Returns:
+            A configured ``Retrying`` controller for one discovery call.
+        """
+        return Retrying(
+            stop=stop_after_attempt(self._max_retries),
+            wait=wait_exponential_jitter(
+                initial=CatalogDefaults.DEFAULT_RETRY_INITIAL_WAIT_SECONDS,
+                max=CatalogDefaults.DEFAULT_RETRY_MAX_WAIT_SECONDS,
+            ),
+            retry=retry_if_exception_type((ClientError, BotoCoreError, APIThrottleError)),
+            reraise=True,
         )
 
     def fetch_all_data(
@@ -228,22 +265,15 @@ class BedrockAPIFetcher:
 
         return models, profiles
 
-    @retry(
-        stop=stop_after_attempt(CatalogDefaults.DEFAULT_MAX_RETRIES),
-        wait=wait_exponential(
-            multiplier=CatalogDefaults.DEFAULT_RETRY_MULTIPLIER,
-            min=CatalogDefaults.DEFAULT_RETRY_MIN_WAIT_SECONDS,
-            max=CatalogDefaults.DEFAULT_RETRY_MAX_WAIT_SECONDS,
-        ),
-        retry=retry_if_exception_type((ClientError, BotoCoreError)),
-        reraise=True,
-    )
     def _fetch_foundation_models(self, region: str) -> List[Dict[str, Any]]:
         """
-        Fetch foundation models from a single region with retry logic.
+        Fetch foundation models from a single region with jittered-backoff retry.
 
-        Uses the AWS Bedrock list-foundation-models API with exponential backoff
-        retry for transient errors.
+        Uses the AWS Bedrock list-foundation-models API. Transient failures — including
+        control-plane ``ThrottlingException`` (raised as the retryable
+        :class:`APIThrottleError`) — are retried with jittered exponential backoff via the
+        instance retry controller (issue #30). ``AccessDeniedException`` is non-retryable
+        and fails fast.
 
         Args:
             region: AWS region identifier
@@ -252,8 +282,22 @@ class BedrockAPIFetcher:
             List of foundation model summaries
 
         Raises:
-            ClientError: If API call fails after retries
-            BotoCoreError: If boto3 client error occurs
+            APIThrottleError: If discovery stays throttled after the retry budget
+            APIFetchError: For non-retryable fetch failures (e.g. access denied)
+            ClientError: If a non-throttle API call fails after retries
+            BotoCoreError: If a boto3 client error persists after retries
+        """
+        return self._build_retrying()(self._fetch_foundation_models_once, region)
+
+    def _fetch_foundation_models_once(self, region: str) -> List[Dict[str, Any]]:
+        """
+        Perform one list-foundation-models call (no retry; invoked by the controller).
+
+        Args:
+            region: AWS region identifier
+
+        Returns:
+            List of foundation model summaries
         """
         try:
             # Get Bedrock control plane client for this region
@@ -280,12 +324,15 @@ class BedrockAPIFetcher:
 
             # Handle specific error cases
             if error_code == "AccessDeniedException":
+                # Non-retryable: a denied permission will not clear on retry.
                 raise APIFetchError(
                     message=CatalogErrorMessages.API_FETCH_AUTH_ERROR.format(error=str(e)),
                     region=region,
                 ) from e
             elif error_code == "ThrottlingException":
-                raise APIFetchError(
+                # Retryable: surface as APIThrottleError so the retry controller retries it
+                # with jittered backoff instead of failing fast (issue #30).
+                raise APIThrottleError(
                     message=CatalogErrorMessages.API_FETCH_THROTTLED.format(error=str(e)),
                     region=region,
                 ) from e
@@ -303,22 +350,15 @@ class BedrockAPIFetcher:
                 region=region,
             ) from e
 
-    @retry(
-        stop=stop_after_attempt(CatalogDefaults.DEFAULT_MAX_RETRIES),
-        wait=wait_exponential(
-            multiplier=CatalogDefaults.DEFAULT_RETRY_MULTIPLIER,
-            min=CatalogDefaults.DEFAULT_RETRY_MIN_WAIT_SECONDS,
-            max=CatalogDefaults.DEFAULT_RETRY_MAX_WAIT_SECONDS,
-        ),
-        retry=retry_if_exception_type((ClientError, BotoCoreError)),
-        reraise=True,
-    )
     def _fetch_inference_profiles(self, region: str) -> List[Dict[str, Any]]:
         """
-        Fetch inference profiles from a single region with retry logic.
+        Fetch inference profiles from a single region with jittered-backoff retry.
 
-        Uses the AWS Bedrock list-inference-profiles API with exponential backoff
-        retry for transient errors. Filters for SYSTEM_DEFINED profiles only.
+        Uses the AWS Bedrock list-inference-profiles API (SYSTEM_DEFINED filter,
+        nextToken-paginated). Transient failures — including control-plane
+        ``ThrottlingException`` (raised as the retryable :class:`APIThrottleError`) — are
+        retried with jittered exponential backoff via the instance retry controller
+        (issue #30). ``AccessDeniedException`` is non-retryable and fails fast.
 
         Args:
             region: AWS region identifier
@@ -327,8 +367,22 @@ class BedrockAPIFetcher:
             List of inference profile summaries (SYSTEM_DEFINED only)
 
         Raises:
-            ClientError: If API call fails after retries
-            BotoCoreError: If boto3 client error occurs
+            APIThrottleError: If discovery stays throttled after the retry budget
+            APIFetchError: For non-retryable fetch failures (e.g. access denied)
+            ClientError: If a non-throttle API call fails after retries
+            BotoCoreError: If a boto3 client error persists after retries
+        """
+        return self._build_retrying()(self._fetch_inference_profiles_once, region)
+
+    def _fetch_inference_profiles_once(self, region: str) -> List[Dict[str, Any]]:
+        """
+        Perform one paginated list-inference-profiles sweep (no retry; controller-invoked).
+
+        Args:
+            region: AWS region identifier
+
+        Returns:
+            List of inference profile summaries (SYSTEM_DEFINED only)
         """
         try:
             # Get Bedrock control plane client for this region
@@ -373,12 +427,15 @@ class BedrockAPIFetcher:
 
             # Handle specific error cases
             if error_code == "AccessDeniedException":
+                # Non-retryable: a denied permission will not clear on retry.
                 raise APIFetchError(
                     message=CatalogErrorMessages.API_FETCH_AUTH_ERROR.format(error=str(e)),
                     region=region,
                 ) from e
             elif error_code == "ThrottlingException":
-                raise APIFetchError(
+                # Retryable: surface as APIThrottleError so the retry controller retries it
+                # with jittered backoff instead of failing fast (issue #30).
+                raise APIThrottleError(
                     message=CatalogErrorMessages.API_FETCH_THROTTLED.format(error=str(e)),
                     region=region,
                 ) from e

--- a/src/bestehorn_llmmanager/bedrock/catalog/bedrock_catalog.py
+++ b/src/bestehorn_llmmanager/bedrock/catalog/bedrock_catalog.py
@@ -68,6 +68,7 @@ class BedrockModelCatalog:
         force_refresh: bool = CatalogDefaults.DEFAULT_FORCE_REFRESH,
         timeout: int = CatalogDefaults.DEFAULT_API_TIMEOUT_SECONDS,
         max_workers: int = CatalogDefaults.DEFAULT_MAX_WORKERS,
+        max_retries: int = CatalogDefaults.DEFAULT_MAX_RETRIES,
         fallback_to_bundled: bool = CatalogDefaults.DEFAULT_FALLBACK_TO_BUNDLED,
         enable_fuzzy_matching: Optional[bool] = None,
     ) -> None:
@@ -83,6 +84,9 @@ class BedrockModelCatalog:
             force_refresh: Force API refresh even if cache is valid
             timeout: API call timeout in seconds
             max_workers: Parallel workers for multi-region API calls
+            max_retries: Retry attempts per discovery API call. Throttled control-plane
+                         calls retry with jittered backoff up to this budget (issue #30);
+                         the default is sized for a fan-out cold-start burst.
             fallback_to_bundled: Use bundled data if API fails
             enable_fuzzy_matching: Enable fuzzy matching in model-CRIS correlation
 
@@ -119,6 +123,7 @@ class BedrockModelCatalog:
             auth_manager=self._auth_manager,
             timeout=timeout,
             max_workers=max_workers,
+            max_retries=max_retries,
         )
 
         self._transformer = CatalogTransformer(

--- a/src/bestehorn_llmmanager/bedrock/exceptions/llm_manager_exceptions.py
+++ b/src/bestehorn_llmmanager/bedrock/exceptions/llm_manager_exceptions.py
@@ -464,6 +464,22 @@ class APIFetchError(LLMManagerError):
         return None
 
 
+class APIThrottleError(APIFetchError):
+    """Raised when an AWS control-plane discovery call is throttled (rate-limited).
+
+    This is a *retryable* subclass of :class:`APIFetchError`: control-plane discovery
+    throttling (``ThrottlingException`` from ``list_foundation_models`` /
+    ``list_inference_profiles``) is transient, so the catalog fetcher's retry controller
+    retries it with jittered exponential backoff. It is kept distinct from a
+    non-retryable ``APIFetchError`` (e.g. ``AccessDeniedException``) so callers can tell
+    "throttled, retries exhausted" apart from "genuinely not found" (issue #30). Because
+    it subclasses ``APIFetchError``, existing ``except APIFetchError`` handlers continue
+    to catch it.
+    """
+
+    pass
+
+
 class CatalogError(LLMManagerError):
     """Base exception for catalog operations."""
 

--- a/src/bestehorn_llmmanager/bedrock/models/catalog_constants.py
+++ b/src/bestehorn_llmmanager/bedrock/models/catalog_constants.py
@@ -159,12 +159,20 @@ class CatalogDefaults:
     # API settings
     DEFAULT_API_TIMEOUT_SECONDS: Final[int] = 30
     DEFAULT_MAX_WORKERS: Final[int] = 10
-    DEFAULT_MAX_RETRIES: Final[int] = 3
+    # Discovery retry budget (issue #30): a lone caller needs only a couple of attempts,
+    # but a synchronized fan-out cold-start (e.g. ~1000 workers) trivially exceeds the
+    # low control-plane RPM limit, so the default is raised to give jittered backoff room
+    # to clear the throttle before a worker fails init.
+    DEFAULT_MAX_RETRIES: Final[int] = 6
 
     # Retry settings
     DEFAULT_RETRY_MIN_WAIT_SECONDS: Final[float] = 1.0
     DEFAULT_RETRY_MAX_WAIT_SECONDS: Final[float] = 10.0
     DEFAULT_RETRY_MULTIPLIER: Final[float] = 1.0
+    # Initial backoff for the jittered exponential wait (wait_exponential_jitter). Jitter
+    # de-correlates a synchronized fleet so cold-starting workers do not retry in lockstep
+    # and re-collide on the throttled discovery API (issue #30).
+    DEFAULT_RETRY_INITIAL_WAIT_SECONDS: Final[float] = 1.0
 
     # AWS regions to query (comprehensive list as of 2025)
     DEFAULT_AWS_REGIONS: Final[List[str]] = [

--- a/test/bestehorn_llmmanager/bedrock/catalog/test_api_fetcher.py
+++ b/test/bestehorn_llmmanager/bedrock/catalog/test_api_fetcher.py
@@ -16,11 +16,22 @@ from botocore.exceptions import ClientError
 
 from bestehorn_llmmanager.bedrock.auth.auth_manager import AuthManager
 from bestehorn_llmmanager.bedrock.catalog.api_fetcher import BedrockAPIFetcher, RawCatalogData
-from bestehorn_llmmanager.bedrock.exceptions.llm_manager_exceptions import APIFetchError
+from bestehorn_llmmanager.bedrock.exceptions.llm_manager_exceptions import (
+    APIFetchError,
+    APIThrottleError,
+)
 from bestehorn_llmmanager.bedrock.models.llm_manager_structures import (
     AuthConfig,
     AuthenticationType,
 )
+
+
+def _client_error(code: str, operation: str = "ListFoundationModels") -> ClientError:
+    """Build a botocore ClientError with the given AWS error code."""
+    return ClientError(
+        error_response={"Error": {"Code": code, "Message": f"{code} occurred"}},
+        operation_name=operation,
+    )
 
 
 @pytest.fixture
@@ -106,12 +117,16 @@ class TestBedrockAPIFetcherInit:
 
     def test_init_with_defaults(self, mock_auth_manager):
         """Test initialization with default parameters."""
+        from bestehorn_llmmanager.bedrock.models.catalog_constants import CatalogDefaults
+
         fetcher = BedrockAPIFetcher(auth_manager=mock_auth_manager)
 
         assert fetcher._auth_manager == mock_auth_manager
         assert fetcher._timeout == 30
         assert fetcher._max_workers == 10
-        assert fetcher._max_retries == 3
+        # Discovery retry budget raised for fan-out cold-start bursts (issue #30).
+        assert fetcher._max_retries == CatalogDefaults.DEFAULT_MAX_RETRIES
+        assert fetcher._max_retries >= 5
 
 
 class TestBedrockAPIFetcherFetchFoundationModels:
@@ -410,3 +425,151 @@ class TestBedrockAPIFetcherParallelExecution:
                         pass
 
             mock_executor_class.assert_called_once_with(max_workers=3)
+
+
+class TestBedrockAPIFetcherThrottleRetry:
+    """Tests for issue #30: throttled control-plane discovery must RETRY (not fail-fast).
+
+    Acceptance criteria from the change request:
+    1. ThrottlingException on the first N calls then success -> discovery RETRIES and
+       returns the catalog; no APIFetchError escapes.
+    2. ThrottlingException is retried (predicate matches) while AccessDeniedException is
+       NOT retried (fails fast).
+    3. Backoff is jittered (the fetcher uses a jittered wait strategy).
+    4. A partial-region throttle does not become a fatal failure: a model present in a
+       successfully-fetched region is returned even if another region is throttle-exhausted.
+    5. "Throttled, retries exhausted" is distinguishable from "genuinely not found"
+       (a dedicated retryable APIThrottleError type, subclass of APIFetchError).
+    """
+
+    def _patch_client(self, mock_auth_manager, mock_client):
+        return patch.object(
+            mock_auth_manager, "get_bedrock_control_client", return_value=mock_client
+        )
+
+    def test_throttle_is_retried_then_succeeds_foundation_models(
+        self, mock_auth_manager, sample_foundation_models
+    ):
+        """AC#1: a ThrottlingException on the first calls is retried until success."""
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.side_effect = [
+            _client_error("ThrottlingException"),
+            _client_error("ThrottlingException"),
+            {"modelSummaries": sample_foundation_models},
+        ]
+        with self._patch_client(mock_auth_manager, mock_client):
+            fetcher = BedrockAPIFetcher(auth_manager=mock_auth_manager, max_retries=5)
+            result = fetcher._fetch_foundation_models(region="us-east-1")
+
+        assert result == sample_foundation_models
+        assert mock_client.list_foundation_models.call_count == 3
+
+    def test_throttle_is_retried_then_succeeds_inference_profiles(
+        self, mock_auth_manager, sample_inference_profiles
+    ):
+        """AC#1: throttled inference-profile discovery is retried until success."""
+        mock_client = MagicMock()
+        mock_client.list_inference_profiles.side_effect = [
+            _client_error("ThrottlingException", operation="ListInferenceProfiles"),
+            {"inferenceProfileSummaries": sample_inference_profiles},
+        ]
+        with self._patch_client(mock_auth_manager, mock_client):
+            fetcher = BedrockAPIFetcher(auth_manager=mock_auth_manager, max_retries=5)
+            result = fetcher._fetch_inference_profiles(region="us-east-1")
+
+        assert result == sample_inference_profiles
+        assert mock_client.list_inference_profiles.call_count == 2
+
+    def test_throttle_retries_exhausted_raises_throttle_error(self, mock_auth_manager):
+        """AC#1/#5: when throttling never clears, a retryable APIThrottleError surfaces.
+
+        APIThrottleError is a subclass of APIFetchError so existing `except APIFetchError`
+        callers still catch it, but the type distinguishes "throttled" from "not found".
+        """
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.side_effect = _client_error("ThrottlingException")
+        with self._patch_client(mock_auth_manager, mock_client):
+            fetcher = BedrockAPIFetcher(auth_manager=mock_auth_manager, max_retries=3)
+            with pytest.raises(APIThrottleError):
+                fetcher._fetch_foundation_models(region="us-east-1")
+
+        assert mock_client.list_foundation_models.call_count == 3
+        assert issubclass(APIThrottleError, APIFetchError)
+
+    def test_access_denied_is_not_retried(self, mock_auth_manager):
+        """AC#2: AccessDeniedException is non-retryable -> fails fast on the first call."""
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.side_effect = _client_error("AccessDeniedException")
+        with self._patch_client(mock_auth_manager, mock_client):
+            fetcher = BedrockAPIFetcher(auth_manager=mock_auth_manager, max_retries=5)
+            with pytest.raises(APIFetchError) as exc_info:
+                fetcher._fetch_foundation_models(region="us-east-1")
+
+        # Exactly one call: not retried.
+        assert mock_client.list_foundation_models.call_count == 1
+        # And it is NOT the retryable throttle subtype.
+        assert not isinstance(exc_info.value, APIThrottleError)
+
+    def test_configurable_retry_budget_is_honored(self, mock_auth_manager):
+        """AC (point 3): the per-instance max_retries actually bounds the attempts.
+
+        Regression guard: previously the @retry decorator hardcoded the default, so the
+        constructor max_retries argument was dead. A higher budget must mean more attempts.
+        """
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.side_effect = _client_error("ThrottlingException")
+        with self._patch_client(mock_auth_manager, mock_client):
+            fetcher = BedrockAPIFetcher(auth_manager=mock_auth_manager, max_retries=6)
+            with pytest.raises(APIThrottleError):
+                fetcher._fetch_foundation_models(region="us-east-1")
+
+        assert mock_client.list_foundation_models.call_count == 6
+
+    def test_default_retry_budget_raised_for_fanout(self):
+        """AC (point 3): the default discovery retry budget is raised for fan-out bursts."""
+        from bestehorn_llmmanager.bedrock.models.catalog_constants import CatalogDefaults
+
+        assert CatalogDefaults.DEFAULT_MAX_RETRIES >= 5
+
+    def test_backoff_uses_jitter(self, mock_auth_manager):
+        """AC#3: the fetcher wait strategy is jittered (de-correlated), not plain exponential.
+
+        A synchronized cold-start fleet must not retry in lockstep. We assert the
+        configured tenacity wait strategy is a jittered variant.
+        """
+        from tenacity import wait_exponential_jitter, wait_random_exponential
+
+        fetcher = BedrockAPIFetcher(auth_manager=mock_auth_manager, max_retries=5)
+        wait_strategy = fetcher._build_retrying().wait
+        assert isinstance(wait_strategy, (wait_exponential_jitter, wait_random_exponential))
+
+    def test_partial_region_throttle_not_fatal_when_model_present_elsewhere(
+        self, mock_auth_manager, sample_foundation_models, sample_inference_profiles
+    ):
+        """AC#4: throttle-exhausted on one region, success on another -> partial catalog.
+
+        fetch_all_data must return data for the region(s) that succeeded rather than
+        failing the whole sweep when at least one region was fetched.
+        """
+        good_client = MagicMock()
+        good_client.list_foundation_models.return_value = {
+            "modelSummaries": sample_foundation_models
+        }
+        good_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": sample_inference_profiles
+        }
+        throttled_client = MagicMock()
+        throttled_client.list_foundation_models.side_effect = _client_error("ThrottlingException")
+        throttled_client.list_inference_profiles.side_effect = _client_error("ThrottlingException")
+
+        def pick_client(region):
+            return good_client if region == "us-east-1" else throttled_client
+
+        with patch.object(mock_auth_manager, "get_bedrock_control_client", side_effect=pick_client):
+            fetcher = BedrockAPIFetcher(auth_manager=mock_auth_manager, max_retries=3)
+            result = fetcher.fetch_all_data(regions=["us-east-1", "us-west-2"])
+
+        assert result.has_data is True
+        assert "us-east-1" in result.successful_regions
+        assert "us-west-2" in result.failed_regions
+        assert len(result.foundation_models["us-east-1"]) == 2


### PR DESCRIPTION
Closes #30.

## Problem

A synchronized fan-out cold-start (≈1000 workers running model/profile discovery at init simultaneously) exceeds the low Bedrock **control-plane** RPM limit (`ListFoundationModels`/`ListInferenceProfiles`). The throttled minority failed init with a self-contradictory `ConfigurationError: model not found in any region` (the model *was* available — discovery was just rate-limited), tripping the Distributed-Map tolerated-failure threshold and failing whole workflows.

## Root causes (`bedrock/catalog/api_fetcher.py`)

1. **Throttle wrap defeated the retry decorator.** The `except ClientError` body re-raised `ThrottlingException` wrapped as `APIFetchError`, but the `@retry` predicate was `retry_if_exception_type((ClientError, BotoCoreError))` — `APIFetchError` matches neither, so a throttle **failed fast** instead of retrying.
2. **No jitter.** Plain `wait_exponential` → a synchronized fleet retries in lockstep and re-collides.
3. **Retry budget was unconfigurable.** The `@retry` decorator hardcoded `DEFAULT_MAX_RETRIES` at class-definition time, so the `BedrockAPIFetcher(max_retries=...)` constructor argument was **dead**.

## Fix

- Add a **retryable** `APIThrottleError(APIFetchError)`; wrap `ThrottlingException` as it. `AccessDeniedException` stays a plain (non-retryable) `APIFetchError`, distinguishing "throttled, retries exhausted" from "genuinely not found" (AC#5).
- Replace the static class-level `@retry` with a **per-call instance controller** (`_build_retrying()` → `tenacity.Retrying`) built from `self._max_retries`, predicate `(ClientError, BotoCoreError, APIThrottleError)`, `reraise=True`. The budget is now honored and configurable.
- Use **`wait_exponential_jitter`** to de-correlate the herd (AC#3).
- Raise `CatalogDefaults.DEFAULT_MAX_RETRIES` 3 → 6; thread `max_retries` from `BedrockModelCatalog` → `BedrockAPIFetcher` (AC: configurable budget).
- A partial-region throttle is already non-fatal (`fetch_all_data` returns partial data, only fails when *all* regions fail); the retry fix means throttled regions **recover** rather than being dropped (AC#4, regression-tested).

## Acceptance criteria → tests (`test_api_fetcher.py::TestBedrockAPIFetcherThrottleRetry`)

| AC | Test |
|----|------|
| #1 throttle retried then succeeds (models + profiles) | `test_throttle_is_retried_then_succeeds_*` |
| #1/#5 exhausted → retryable `APIThrottleError` | `test_throttle_retries_exhausted_raises_throttle_error` |
| #2 `AccessDeniedException` not retried (fast-fail) | `test_access_denied_is_not_retried` |
| #3 configurable + raised budget | `test_configurable_retry_budget_is_honored`, `test_default_retry_budget_raised_for_fanout` |
| #3 jittered backoff | `test_backoff_uses_jitter` |
| #4 partial-region throttle non-fatal | `test_partial_region_throttle_not_fatal_when_model_present_elsewhere` |

## Backward compatibility

`AccessDeniedException` still fails fast; `APIThrottleError` subclasses `APIFetchError` so existing `except APIFetchError` handlers keep working; default behavior is unchanged except the (intended) higher discovery retry budget.

## Proof (local, worktree venv, ruff 0.15.18 / tenacity 9.1.4)

- `ruff format --check src/ test/` ✓, `ruff check src/ test/` ✓, `mypy --exclude="_version" src/` ✓ (100 files)
- Full unit suite `pytest test/bestehorn_llmmanager/ -n auto` → **2628 passed, 7 skipped, 0 failed** (baseline 2620 + 8 new tests)