### PR TITLE
feat(parallel): usable Bedrock prompt caching on converse_parallel (#29)

### DIFF
--- a/docs/forLLMConsumption.md
+++ b/docs/forLLMConsumption.md
@@ -526,9 +526,23 @@ ParallelLLMManager(
     parallel_config: Optional[ParallelProcessingConfig] = None,  # Optional: Parallel processing config
     default_inference_config: Optional[Dict] = None,     # Optional: Default inference parameters
     timeout: int = 300,                                   # Optional: Request timeout in seconds
-    log_level: Union[int, str] = logging.WARNING         # Optional: Logging level (default: WARNING)
+    log_level: Union[int, str] = logging.WARNING,        # Optional: Logging level (default: WARNING)
+    cache_config: Optional[CacheConfig] = None           # Optional: Bedrock prompt caching (forwarded to internal LLMManager)
 )
 ```
+
+**Prompt caching on the parallel path:** pass `cache_config=CacheConfig(enabled=True, ...)`
+to enable Bedrock prompt caching for parallel requests. It is forwarded to the internal
+single-call manager, so the existing cache-point injection/validation applies to every
+`converse_parallel` request. Build messages with a stable prefix and a cache point at its
+end (`ConverseMessageBuilder.add_cache_point()`); caller-placed cache points are preserved
+through the parallel submission path. After a batch, read per-request cache tokens via
+`response.get_cache_read_tokens()`/`get_cache_write_tokens()`, or the batch aggregate via
+`ParallelResponse.get_cache_metrics()` (hit ratio + cache-served tokens) and
+`get_total_tokens_used()`. With `cache_config=None` (default) the parallel path is
+unchanged. Note: caching only takes effect when the stable prefix meets the model's
+minimum checkpoint size (e.g. 4,096 tokens for Claude Opus 4.x); a sub-minimum prefix is
+not cached.
 
 #### Core Methods
 

--- a/src/bestehorn_llmmanager/bedrock/models/parallel_structures.py
+++ b/src/bestehorn_llmmanager/bedrock/models/parallel_structures.py
@@ -13,6 +13,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Set
 
 from .bedrock_response import BedrockResponse
+from .cache_structures import CacheMetrics
 from .parallel_constants import ParallelConfig, ParallelProcessingFields
 
 
@@ -524,6 +525,49 @@ class ParallelResponse:
                     total_usage[key] += usage.get(key, 0)
 
         return total_usage
+
+    def get_cache_metrics(self) -> CacheMetrics:
+        """
+        Derive aggregate prompt-caching metrics across the batch (issue #29, CR-3).
+
+        Each successful response carries the Bedrock Converse ``usage`` cache fields
+        (``cache_read_tokens`` / ``cache_write_tokens``); this aggregates them so callers
+        can measure the realized cache effectiveness of a parallel fan-out:
+
+        - a request with ``cache_read_tokens > 0`` is counted as a cache **hit** (it read
+          a previously-written prefix at the reduced cached rate);
+        - a request with no cache reads is counted as a cache **miss** (it either wrote
+          the cache or did not cache at all);
+        - ``cache_savings_tokens`` is the total input tokens served from cache (the sum of
+          cache-read tokens), and ``cache_hit_ratio`` is hits / total successful requests.
+
+        With caching disabled (no cache tokens on any response) every field is zero, so a
+        batch run without ``cache_config`` reports exactly as before.
+
+        Returns:
+            A :class:`CacheMetrics` with the read-derived hit ratio, hit/miss counts, and
+            cache-served token savings for this batch.
+        """
+        successful = self.get_successful_responses()
+        total = len(successful)
+
+        cache_read_total = 0
+        hits = 0
+        for response in successful.values():
+            read_tokens = response.get_cache_read_tokens()
+            cache_read_total += read_tokens
+            if read_tokens > 0:
+                hits += 1
+
+        misses = total - hits
+        hit_ratio = (hits / total) if total else 0.0
+
+        return CacheMetrics(
+            cache_hit_ratio=hit_ratio,
+            cache_savings_tokens=cache_read_total,
+            total_cache_hits=hits,
+            total_cache_misses=misses,
+        )
 
     def get_average_latency(self) -> Optional[float]:
         """

--- a/src/bestehorn_llmmanager/bedrock/validators/request_validator.py
+++ b/src/bestehorn_llmmanager/bedrock/validators/request_validator.py
@@ -207,8 +207,20 @@ class RequestValidator:
                 errors.append(f"Message {message_index}, block {i} must be a dictionary")
                 continue
 
-            # Check that block has at least one content type
-            content_types = ["text", "image", "document", "video", "toolUse", "toolResult"]
+            # Check that block has at least one content type. "cachePoint" is a valid
+            # Converse content block (a caller-placed prompt-caching checkpoint built via
+            # ConverseMessageBuilder.add_cache_point()); the parallel path must accept it
+            # so caller-placed cache points survive submission, not reject them as empty
+            # blocks (issue #29, CR-2).
+            content_types = [
+                "text",
+                "image",
+                "document",
+                "video",
+                "toolUse",
+                "toolResult",
+                "cachePoint",
+            ]
             if not any(content_type in block for content_type in content_types):
                 errors.append(
                     f"Message {message_index}, block {i} must have at least one content type"

--- a/src/bestehorn_llmmanager/parallel_llm_manager.py
+++ b/src/bestehorn_llmmanager/parallel_llm_manager.py
@@ -17,6 +17,7 @@ from .bedrock.exceptions.parallel_exceptions import (
 )
 from .bedrock.executors.thread_parallel_executor import ThreadParallelExecutor
 from .bedrock.models.bedrock_response import BedrockResponse
+from .bedrock.models.cache_structures import CacheConfig
 from .bedrock.models.llm_manager_constants import LLMManagerConfig
 from .bedrock.models.llm_manager_structures import (
     AuthConfig,
@@ -93,6 +94,7 @@ class ParallelLLMManager:
         region_order: Optional[str] = None,
         access_method_preference: Optional[str] = None,
         global_cris_fraction: Optional[float] = None,
+        cache_config: Optional[CacheConfig] = None,
     ) -> None:
         """
         Initialize the Parallel LLM Manager.
@@ -129,6 +131,13 @@ class ParallelLLMManager:
                 approximately this share of requests is routed to the global CRIS profile,
                 the rest follow the default order. None (default) disables interleaving.
                 Forwarded to the underlying LLMManager.
+            cache_config: Prompt-caching configuration (issue #29). Forwarded to the
+                internal LLMManager so the existing cache-point injection/validation
+                applies to parallel requests too (each parallel request executes via
+                that manager's converse()). None (default) => caching disabled, i.e. the
+                parallel path is byte-identical to before. To enable, pass
+                CacheConfig(enabled=True, ...) and build messages with cacheable blocks /
+                an explicit cache point at the end of the stable prefix.
 
         Raises:
             ParallelConfigurationError: If configuration is invalid
@@ -161,6 +170,7 @@ class ParallelLLMManager:
             region_order=region_order,
             access_method_preference=access_method_preference,
             global_cris_fraction=global_cris_fraction,
+            cache_config=cache_config,
         )
 
         # Initialize parallel processing components

--- a/test/bestehorn_llmmanager/test_parallel_llm_manager_caching.py
+++ b/test/bestehorn_llmmanager/test_parallel_llm_manager_caching.py
@@ -1,0 +1,208 @@
+"""
+Tests for prompt caching on the parallel fan-out path (issue #29).
+
+Covers the three change-requests:
+- CR-1: ``ParallelLLMManager`` accepts ``cache_config`` and forwards it to the internal
+  ``LLMManager`` so the existing cache-point injection activates for parallel requests.
+- CR-2: caller-placed cache points on a ``BedrockConverseRequest`` survive the parallel
+  submission path (``messages``/``system`` are passed through unchanged).
+- CR-3: per-request cache tokens and an aggregate cache hit ratio are surfaced on the
+  parallel result.
+
+Backward compatibility: with ``cache_config=None`` the parallel path is byte-identical to
+today (no cache-point manager, caching disabled).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from bestehorn_llmmanager.bedrock.models.bedrock_response import BedrockResponse
+from bestehorn_llmmanager.bedrock.models.cache_structures import CacheConfig, CacheStrategy
+from bestehorn_llmmanager.bedrock.models.parallel_structures import (
+    BedrockConverseRequest,
+    ParallelResponse,
+)
+from bestehorn_llmmanager.parallel_llm_manager import ParallelLLMManager
+
+
+def _make_response(
+    *,
+    request_id: str,
+    cache_read: int = 0,
+    cache_write: int = 0,
+    input_tokens: int = 100,
+    output_tokens: int = 10,
+) -> BedrockResponse:
+    """Build a successful BedrockResponse-like mock with the given usage tokens."""
+    response = MagicMock(spec=BedrockResponse)
+    response.success = True
+    response.get_usage.return_value = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+        "cache_read_tokens": cache_read,
+        "cache_write_tokens": cache_write,
+    }
+    response.get_cache_read_tokens.return_value = cache_read
+    response.get_cache_write_tokens.return_value = cache_write
+    response.get_metrics.return_value = {"api_latency_ms": 5.0}
+    response.get_warnings.return_value = []
+    response.get_last_error.return_value = None
+    return response
+
+
+class TestParallelManagerCacheConfigForwarding:
+    """CR-1: cache_config is forwarded to the internal LLMManager."""
+
+    @patch("bestehorn_llmmanager.llm_manager.BedrockModelCatalog")
+    def test_cache_config_enabled_is_forwarded_and_activates_injection(self, mock_catalog_cls):
+        """Constructing with cache_config(enabled=True) gives the internal manager an
+        enabled cache config and a constructed CachePointManager."""
+        mock_catalog_cls.return_value = MagicMock()
+        cache_config = CacheConfig(enabled=True, strategy=CacheStrategy.CONSERVATIVE)
+
+        manager = ParallelLLMManager(
+            models=["Claude Sonnet 4 20250514"],
+            regions=["us-east-1"],
+            cache_config=cache_config,
+        )
+
+        internal = manager.get_underlying_llm_manager()
+        assert internal._cache_config is cache_config
+        assert internal._cache_config.enabled is True
+        # The injection path is gated on a constructed CachePointManager.
+        assert internal._cache_point_manager is not None
+
+    @patch("bestehorn_llmmanager.llm_manager.BedrockModelCatalog")
+    def test_cache_config_none_keeps_caching_disabled(self, mock_catalog_cls):
+        """Backward-compat: omitting cache_config => internal manager has caching
+        disabled and no CachePointManager (byte-identical to today)."""
+        mock_catalog_cls.return_value = MagicMock()
+
+        manager = ParallelLLMManager(
+            models=["Claude Sonnet 4 20250514"],
+            regions=["us-east-1"],
+        )
+
+        internal = manager.get_underlying_llm_manager()
+        assert internal._cache_config.enabled is False
+        assert internal._cache_point_manager is None
+
+
+class TestParallelManagerCachePointPassthrough:
+    """CR-2: caller-placed cache points survive the parallel submission path."""
+
+    def test_caller_cache_point_preserved_in_converse_args(self):
+        """A caller-placed cachePoint block in messages is passed through verbatim by
+        BedrockConverseRequest.to_converse_args() in the same position."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"text": "stable prefix"},
+                    {"cachePoint": {"type": "default"}},
+                    {"text": "variable suffix"},
+                ],
+            }
+        ]
+        system = [{"text": "system instruction"}]
+        request = BedrockConverseRequest(messages=messages, system=system)
+
+        args = request.to_converse_args()
+
+        # Messages (incl. the cachePoint block, in position) and system pass through unchanged.
+        assert args["messages"] == messages
+        assert args["messages"][0]["content"][1] == {"cachePoint": {"type": "default"}}
+        assert args["system"] == system
+
+    @patch("bestehorn_llmmanager.llm_manager.BedrockModelCatalog")
+    @patch("bestehorn_llmmanager.llm_manager.LLMManager.converse")
+    def test_parallel_path_forwards_caller_cache_point_to_converse(
+        self, mock_converse, mock_catalog_cls
+    ):
+        """When a parallel request carries a caller-placed cachePoint, the messages
+        reaching converse() preserve that cache point in position."""
+        mock_catalog_cls.return_value = MagicMock()
+        seen = {}
+
+        def capture(**kwargs):
+            seen["messages"] = kwargs.get("messages")
+            return _make_response(request_id="r")
+
+        mock_converse.side_effect = capture
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"text": "stable prefix"},
+                    {"cachePoint": {"type": "default"}},
+                    {"text": "variable suffix"},
+                ],
+            }
+        ]
+        manager = ParallelLLMManager(
+            models=["Claude Sonnet 4 20250514"],
+            regions=["us-east-1"],
+            cache_config=CacheConfig(enabled=True),
+        )
+        request = BedrockConverseRequest(messages=messages)
+        manager.converse_parallel(requests=[request])
+
+        assert seen["messages"] is not None
+        # The caller-placed cache point survived to converse() in the same position.
+        assert {"cachePoint": {"type": "default"}} in seen["messages"][0]["content"]
+        assert seen["messages"][0]["content"][1] == {"cachePoint": {"type": "default"}}
+
+
+class TestParallelResponseCacheMetrics:
+    """CR-3: per-request cache tokens + aggregate cache hit ratio on the parallel result."""
+
+    def test_total_tokens_used_includes_cache_tokens(self):
+        """The existing aggregate includes cache read/write tokens across the batch."""
+        resp = ParallelResponse(
+            success=True,
+            request_responses={
+                "a": _make_response(request_id="a", cache_read=0, cache_write=4096),
+                "b": _make_response(request_id="b", cache_read=4096, cache_write=0),
+            },
+        )
+
+        totals = resp.get_total_tokens_used()
+        assert totals["cache_write_tokens"] == 4096
+        assert totals["cache_read_tokens"] == 4096
+
+    def test_get_cache_metrics_derives_hit_ratio(self):
+        """CR-3: get_cache_metrics() exposes read/write totals and a derived hit ratio.
+
+        First request writes the cache (miss), the next two read it (hits) => 2/3 hits.
+        """
+        resp = ParallelResponse(
+            success=True,
+            request_responses={
+                "a": _make_response(request_id="a", cache_read=0, cache_write=4096),
+                "b": _make_response(request_id="b", cache_read=4096, cache_write=0),
+                "c": _make_response(request_id="c", cache_read=4096, cache_write=0),
+            },
+        )
+
+        metrics = resp.get_cache_metrics()
+        assert metrics.cache_savings_tokens == 4096 * 2  # tokens served from cache
+        assert metrics.total_cache_hits == 2
+        assert metrics.total_cache_misses == 1
+        assert abs(metrics.cache_hit_ratio - (2 / 3)) < 1e-9
+
+    def test_get_cache_metrics_zero_when_caching_disabled(self):
+        """With caching disabled (no cache tokens), metrics are all zero — exactly as
+        today (CR-3 backward-compat)."""
+        resp = ParallelResponse(
+            success=True,
+            request_responses={
+                "a": _make_response(request_id="a", cache_read=0, cache_write=0),
+                "b": _make_response(request_id="b", cache_read=0, cache_write=0),
+            },
+        )
+
+        metrics = resp.get_cache_metrics()
+        assert metrics.cache_hit_ratio == 0.0
+        assert metrics.total_cache_hits == 0
+        assert metrics.cache_savings_tokens == 0


### PR DESCRIPTION
Closes #29.

## Problem

`ParallelLLMManager.converse_parallel` dominates the project's input-token cost, but prompt caching could not be turned on through the public API: the constructor never accepted or forwarded `cache_config`, so the internal `LLMManager` always got `CacheConfig(enabled=False)`. Three opt-in, backward-compatible changes:

## CR-1 (primary) — forward `cache_config`

`ParallelLLMManager.__init__` gains `cache_config: Optional[CacheConfig] = None` and forwards it to the internal `LLMManager`. Each parallel request already executes via `self._llm_manager.converse(...)`, so this single forward activates the **existing** cache-point injection/validation (`llm_manager.py:1062`) for parallel requests — no new injection logic.

## CR-2 — honour caller-placed cache points (found + fixed a real defect)

The passthrough test surfaced a genuine bug: the parallel `RequestValidator` content-type allowlist (`["text","image","document","video","toolUse","toolResult"]`) **omitted `cachePoint`**, so a caller-placed cache-point block was rejected as an empty content block *before reaching* `converse()`. The single-call path doesn't run this validator — which is exactly why caching worked for single calls but not in parallel. Added `"cachePoint"` to the allowlist. `BedrockConverseRequest.to_converse_args()` already passes `messages`/`system` through verbatim.

## CR-3 — surface cache metrics

Added `ParallelResponse.get_cache_metrics() -> CacheMetrics` (read-derived hit ratio + cache-served token savings). Per-request cache tokens were already exposed (`BedrockResponse.get_cache_read_tokens()`/`get_cache_write_tokens()`) and `get_total_tokens_used()` already aggregated them; this adds the hit-ratio convenience.

## Backward compatibility

With `cache_config=None` the internal manager gets `CacheConfig(enabled=False)` and the parallel path is byte-identical to before; the validator change only **accepts** an additional valid block type (never rejects anything previously accepted). `get_cache_metrics()` is additive.

**Deferred (noted):** the optional per-request `BedrockConverseRequest.cache_config` override — the issue marks it "nice-to-have", and it would perturb the request-id content hash for marginal value.

## Tests (`test_parallel_llm_manager_caching.py`, 7 new)

- CR-1: `cache_config` forwarded + activates `CachePointManager`; `None` keeps caching disabled (no manager).
- CR-2: caller cachePoint preserved in `to_converse_args()` position; survives `converse_parallel` to `converse()`.
- CR-3: aggregate includes cache tokens; `get_cache_metrics()` derives hit ratio; zero when disabled.

## Proof (local, worktree venv)

- `ruff format --check` ✓, `ruff check` ✓, `mypy --exclude="_version" src/` ✓ (100 files)
- Full unit suite `pytest test/bestehorn_llmmanager/ -n auto` → **2627 passed, 7 skipped, 0 failed** (baseline 2620 + 7 new)