### PR TITLE
fix(video): align VideoFormatEnum with the Bedrock VideoBlock format set (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ message = create_user_message()\
 # Supported formats:
 # Images: JPEG, PNG, GIF, WEBP
 # Documents: PDF, CSV, DOC, DOCX, XLS, XLSX, HTML, TXT, MD  
-# Videos: MP4, MOV, AVI, WEBM, MKV
+# Videos: MP4, MOV, WEBM, MKV, FLV, MPEG, MPG, WMV, 3GP
 ```
 
 ### 🌊 Streaming Responses

--- a/docs/forLLMConsumption - bestehorn_llmmanager.md
+++ b/docs/forLLMConsumption - bestehorn_llmmanager.md
@@ -278,9 +278,13 @@ from bestehorn_llmmanager import VideoFormatEnum
 class VideoFormatEnum(str, Enum):
     MP4 = "mp4"
     MOV = "mov"
-    AVI = "avi"
     WEBM = "webm"
     MKV = "mkv"
+    FLV = "flv"
+    MPEG = "mpeg"
+    MPG = "mpg"
+    WMV = "wmv"
+    THREE_GP = "three_gp"
 ```
 
 ### MessageBuilder Properties and Utilities
@@ -2980,9 +2984,13 @@ class DocumentFormatEnum(str, Enum):
 class VideoFormatEnum(str, Enum):
     MP4 = "mp4"
     MOV = "mov"
-    AVI = "avi"
     WEBM = "webm"
     MKV = "mkv"
+    FLV = "flv"
+    MPEG = "mpeg"
+    MPG = "mpg"
+    WMV = "wmv"
+    THREE_GP = "three_gp"
 
 # File type detection methods
 class DetectionMethodEnum(str, Enum):

--- a/docs/forLLMConsumption.md
+++ b/docs/forLLMConsumption.md
@@ -278,9 +278,13 @@ from bestehorn_llmmanager import VideoFormatEnum
 class VideoFormatEnum(str, Enum):
     MP4 = "mp4"
     MOV = "mov"
-    AVI = "avi"
     WEBM = "webm"
     MKV = "mkv"
+    FLV = "flv"
+    MPEG = "mpeg"
+    MPG = "mpg"
+    WMV = "wmv"
+    THREE_GP = "three_gp"
 ```
 
 ### MessageBuilder Properties and Utilities
@@ -3027,9 +3031,13 @@ class DocumentFormatEnum(str, Enum):
 class VideoFormatEnum(str, Enum):
     MP4 = "mp4"
     MOV = "mov"
-    AVI = "avi"
     WEBM = "webm"
     MKV = "mkv"
+    FLV = "flv"
+    MPEG = "mpeg"
+    MPG = "mpg"
+    WMV = "wmv"
+    THREE_GP = "three_gp"
 
 # File type detection methods
 class DetectionMethodEnum(str, Enum):

--- a/src/bestehorn_llmmanager/message_builder_constants.py
+++ b/src/bestehorn_llmmanager/message_builder_constants.py
@@ -117,7 +117,18 @@ class SupportedFormats:
         "txt",
         "md",
     ]
-    VIDEO_FORMATS: Final[List[str]] = ["mp4", "mov", "avi", "webm", "mkv"]
+    # Matches the Bedrock VideoBlock format enum exactly (issue #33): no "avi".
+    VIDEO_FORMATS: Final[List[str]] = [
+        "mp4",
+        "mov",
+        "webm",
+        "mkv",
+        "flv",
+        "mpeg",
+        "mpg",
+        "wmv",
+        "three_gp",
+    ]
 
     @classmethod
     def get_all_supported_formats(cls) -> Dict[str, List[str]]:

--- a/src/bestehorn_llmmanager/message_builder_enums.py
+++ b/src/bestehorn_llmmanager/message_builder_enums.py
@@ -58,14 +58,20 @@ class VideoFormatEnum(str, Enum):
     """
     Enumeration of supported video formats for the Converse API.
 
-    These formats are compatible with AWS Bedrock video processing capabilities.
+    These values match the AWS Bedrock Converse ``VideoBlock`` ``format`` enum exactly
+    (mkv, mov, mp4, webm, flv, mpeg, mpg, wmv, three_gp). ``avi`` is intentionally absent:
+    Bedrock does not accept it, so sending it always produced a rejected request.
     """
 
     MP4 = "mp4"
     MOV = "mov"
-    AVI = "avi"
     WEBM = "webm"
     MKV = "mkv"
+    FLV = "flv"
+    MPEG = "mpeg"
+    MPG = "mpg"
+    WMV = "wmv"
+    THREE_GP = "three_gp"
 
 
 class DetectionMethodEnum(str, Enum):

--- a/src/bestehorn_llmmanager/util/file_type_detector/detector_constants.py
+++ b/src/bestehorn_llmmanager/util/file_type_detector/detector_constants.py
@@ -46,8 +46,8 @@ class MagicBytesConstants:
     ]
 
     MOV_SIGNATURE: Final[bytes] = b"\x00\x00\x00\x14ftypqt"
-    AVI_SIGNATURE: Final[bytes] = b"RIFF"
-    AVI_FORMAT_SIGNATURE: Final[bytes] = b"AVI "
+    # AVI magic-byte constants intentionally removed (issue #33): Bedrock does not accept
+    # "avi", so the detector no longer recognizes it as a supported video format.
     WEBM_SIGNATURE: Final[bytes] = b"\x1a\x45\xdf\xa3"
     MKV_SIGNATURE: Final[bytes] = b"\x1a\x45\xdf\xa3"
 
@@ -77,12 +77,19 @@ class FileExtensionConstants:
         ".markdown": "md",
     }
 
+    # Extension → Bedrock video format token. Matches the VideoFormatEnum / Bedrock set
+    # (issue #33): no ".avi" (Bedrock rejects avi); ".3gp" maps to the Bedrock token
+    # "three_gp".
     VIDEO_EXTENSIONS: Final[Dict[str, str]] = {
         ".mp4": "mp4",
         ".mov": "mov",
-        ".avi": "avi",
         ".webm": "webm",
         ".mkv": "mkv",
+        ".flv": "flv",
+        ".mpeg": "mpeg",
+        ".mpg": "mpg",
+        ".wmv": "wmv",
+        ".3gp": "three_gp",
     }
 
     @classmethod

--- a/src/bestehorn_llmmanager/util/file_type_detector/file_type_detector.py
+++ b/src/bestehorn_llmmanager/util/file_type_detector/file_type_detector.py
@@ -466,19 +466,9 @@ class FileTypeDetector(BaseDetector):
                 metadata={"magic_bytes": MagicBytesConstants.MOV_SIGNATURE.hex()},
             )
 
-        # Check AVI signature (RIFF + AVI)
-        if (
-            header.startswith(MagicBytesConstants.AVI_SIGNATURE)
-            and len(content) >= 12
-            and MagicBytesConstants.AVI_FORMAT_SIGNATURE in content[:12]
-        ):
-            return self._create_success_result(
-                detected_format="avi",
-                confidence=DetectionConstants.HIGH_CONFIDENCE,
-                detection_method=DetectionMethodEnum.CONTENT,
-                filename=filename,
-                metadata={"magic_bytes": header[:12].hex()},
-            )
+        # NOTE: AVI is intentionally NOT detected. Bedrock does not accept "avi" as a
+        # video format (issue #33), so detecting it would only produce a request the API
+        # rejects. AVI content therefore falls through to "unsupported format".
 
         # Check WEBM/MKV signature (same signature, differentiate by extension if available)
         if header.startswith(MagicBytesConstants.WEBM_SIGNATURE):

--- a/test/bestehorn_llmmanager/test_message_builder.py
+++ b/test/bestehorn_llmmanager/test_message_builder.py
@@ -556,18 +556,18 @@ class TestAddVideoBytesMethod:
         mock_detector_class.return_value = mock_detector
 
         mock_result = DetectionResult(
-            detected_format="flv",  # Unsupported format
+            detected_format="avi",  # Unsupported format (Bedrock rejects avi; issue #33)
             confidence=0.95,
             detection_method=DetectionMethodEnum.CONTENT,
-            filename="test.flv",
+            filename="test.avi",
         )
         mock_detector.detect_video_format.return_value = mock_result
 
         builder = ConverseMessageBuilder(role=RolesEnum.USER)
-        video_data = b"flv data"
+        video_data = b"avi data"
 
         with pytest.raises(RequestValidationError, match="Unsupported format"):
-            builder.add_video_bytes(bytes=video_data, filename="test.flv")
+            builder.add_video_bytes(bytes=video_data, filename="test.avi")
 
 
 class TestAddLocalVideoMethod:

--- a/test/bestehorn_llmmanager/test_video_format_enum.py
+++ b/test/bestehorn_llmmanager/test_video_format_enum.py
@@ -1,0 +1,72 @@
+"""
+Tests for VideoFormatEnum ↔ Bedrock alignment (issue #33).
+
+`VideoFormatEnum` must match the authoritative Bedrock Converse VideoBlock ``format``
+enum exactly: mkv, mov, mp4, webm, flv, mpeg, mpg, wmv, three_gp — with NO ``avi`` (which
+Bedrock rejects). The file-type detector extension mappings and the
+``SupportedFormats.VIDEO_FORMATS`` list must stay in lockstep.
+"""
+
+from bestehorn_llmmanager.message_builder_constants import SupportedFormats
+from bestehorn_llmmanager.message_builder_enums import VideoFormatEnum
+from bestehorn_llmmanager.util.file_type_detector.detector_constants import (
+    FileExtensionConstants,
+)
+
+# The authoritative Bedrock VideoFormat enum (boto3 bedrock-runtime service model).
+BEDROCK_VIDEO_FORMATS = {"mkv", "mov", "mp4", "webm", "flv", "mpeg", "mpg", "wmv", "three_gp"}
+
+
+class TestVideoFormatEnumMatchesBedrock:
+    """The enum value set equals the Bedrock-supported set exactly."""
+
+    def test_enum_values_equal_bedrock_set(self):
+        """VideoFormatEnum values == the Bedrock VideoFormat enum, exactly."""
+        assert {fmt.value for fmt in VideoFormatEnum} == BEDROCK_VIDEO_FORMATS
+
+    def test_avi_removed(self):
+        """avi is not a valid Bedrock video format and must not be in the enum."""
+        assert "avi" not in {fmt.value for fmt in VideoFormatEnum}
+        assert not hasattr(VideoFormatEnum, "AVI")
+
+    def test_newly_supported_formats_present(self):
+        """The five formats Bedrock supports that were previously missing are present."""
+        values = {fmt.value for fmt in VideoFormatEnum}
+        for fmt in ("flv", "mpeg", "mpg", "wmv", "three_gp"):
+            assert fmt in values
+
+    def test_three_gp_member_value(self):
+        """three_gp uses the Bedrock token value 'three_gp' (not '3gp')."""
+        assert VideoFormatEnum.THREE_GP.value == "three_gp"
+
+
+class TestSupportedVideoFormatsInLockstep:
+    """SupportedFormats.VIDEO_FORMATS matches the enum (no avi, includes the new five)."""
+
+    def test_supported_video_formats_equal_bedrock_set(self):
+        assert set(SupportedFormats.VIDEO_FORMATS) == BEDROCK_VIDEO_FORMATS
+
+    def test_supported_video_formats_have_no_avi(self):
+        assert "avi" not in SupportedFormats.VIDEO_FORMATS
+
+
+class TestVideoExtensionMappingsInLockstep:
+    """File-type detector video extension mappings match the supported set."""
+
+    def test_avi_extension_removed(self):
+        assert ".avi" not in FileExtensionConstants.VIDEO_EXTENSIONS
+
+    def test_new_extensions_present_and_map_to_bedrock_values(self):
+        ext_map = FileExtensionConstants.VIDEO_EXTENSIONS
+        assert ext_map.get(".flv") == "flv"
+        assert ext_map.get(".mpeg") == "mpeg"
+        assert ext_map.get(".mpg") == "mpg"
+        assert ext_map.get(".wmv") == "wmv"
+        # .3gp is the conventional extension; it must map to the Bedrock token "three_gp".
+        assert ext_map.get(".3gp") == "three_gp"
+
+    def test_all_mapped_video_values_are_valid_bedrock_formats(self):
+        """Every value the detector maps an extension to is a valid VideoFormatEnum value."""
+        valid = {fmt.value for fmt in VideoFormatEnum}
+        for ext, value in FileExtensionConstants.VIDEO_EXTENSIONS.items():
+            assert value in valid, f"{ext} maps to non-Bedrock video format {value!r}"

--- a/test/bestehorn_llmmanager/util/file_type_detector/test_file_type_detector.py
+++ b/test/bestehorn_llmmanager/util/file_type_detector/test_file_type_detector.py
@@ -315,15 +315,17 @@ class TestVideoDetection:
         assert result.is_successful
         assert result.detected_format == "mov"
 
-    def test_detect_avi_by_content(self):
-        """Test AVI detection by content."""
+    def test_avi_is_not_detected_as_supported_video(self):
+        """AVI is not a Bedrock-supported video format (issue #33): it must NOT be
+        detected. AVI content falls through to an unsuccessful (unsupported) result
+        rather than producing a request Bedrock would reject."""
         detector = FileTypeDetector()
         avi_content = b"RIFF\x1c\x00\x00\x00AVI "
 
         result = detector.detect_video_format(content=avi_content, filename="test.avi")
 
-        assert result.is_successful
-        assert result.detected_format == "avi"
+        assert not result.is_successful
+        assert result.detected_format != "avi"
 
     def test_detect_webm_by_content(self):
         """Test WEBM detection by content."""


### PR DESCRIPTION
Closes #33.

## Problem

`VideoFormatEnum` shipped an **invalid** format (`avi`, which Bedrock rejects) and **omitted five** formats Bedrock supports — so `avi` requests were always rejected and valid `flv/mpeg/mpg/wmv/3gp` videos could not be sent.

## Fix

Aligned the enum to the **authoritative** Bedrock VideoFormat set (verified against the boto3 `bedrock-runtime` service model, botocore 1.43.34): `mkv, mov, mp4, webm, flv, mpeg, mpg, wmv, three_gp` — removed `avi`, added `FLV/MPEG/MPG/WMV/THREE_GP` (`THREE_GP = "three_gp"`).

**Lockstep updates:**
- `SupportedFormats.VIDEO_FORMATS` matches the enum set.
- File-type detector `VIDEO_EXTENSIONS`: drop `.avi`, add `.flv/.mpeg/.mpg/.wmv` and `.3gp → "three_gp"`.
- Removed the AVI magic-byte detection branch (and the now-unused `AVI_SIGNATURE`/`AVI_FORMAT_SIGNATURE`): detecting AVI would only build a request Bedrock rejects, so AVI content now falls through to a clear "unsupported format" error.

## AVI migration: hard removal (not a deprecation alias)

`VideoFormatEnum.AVI` only ever produced requests Bedrock **rejects**, so there was no working AVI path to preserve. A deprecation alias would keep a guaranteed-broken value alive that still fails at the API. Callers who auto-detect an AVI now get a clear `RequestValidationError: unsupported video format` instead of a silently-invalid request.

## Tests

- New `test_video_format_enum.py` (9 tests): enum == Bedrock set; no `avi`; the five new formats present; `three_gp` value; `SupportedFormats.VIDEO_FORMATS` and detector extension mappings in lockstep; every mapped extension value is a valid enum value.
- Two pre-existing tests updated to the new contract (not weakened): AVI is no longer detected; the "unsupported format" example switched from `flv` (now supported) to `avi` (now correctly unsupported).
- README + both `docs/forLLMConsumption*.md` enum blocks updated.

## Proof (local, worktree venv)

- `ruff format --check` ✓, `ruff check` ✓, `mypy --exclude="_version" src/` ✓ (100 files)
- Full unit suite `pytest test/bestehorn_llmmanager/ -n auto` → **2644 passed, 7 skipped, 0 failed**