### PR TITLE
fix(stop-reason): complete stopReason coverage with a canonical, unified model (#37)

### DIFF
--- a/src/bestehorn_llmmanager/bedrock/models/bedrock_response.py
+++ b/src/bestehorn_llmmanager/bedrock/models/bedrock_response.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from .llm_manager_constants import ConverseAPIFields
 from .llm_manager_structures import RequestAttempt, ValidationAttempt
+from .stop_reason import StopReasonCategory, StopReasonClassifier
 
 
 @dataclass
@@ -206,6 +207,22 @@ class BedrockResponse:
             return self.response_data.get(ConverseAPIFields.STOP_REASON)
         except (KeyError, TypeError, AttributeError):
             return None
+
+    def get_stop_reason_category(self) -> StopReasonCategory:
+        """
+        Get the canonical retry/failover category of this response's stop reason.
+
+        Classifies the raw ``stopReason`` (see :meth:`get_stop_reason`) into a
+        :class:`StopReasonCategory` so callers can branch on intent rather than on raw
+        strings — e.g. ``model_context_window_exceeded`` and ``malformed_*`` are
+        retryable (the former only against a different model/region), while ``end_turn`` /
+        ``tool_use`` / ``stop_sequence`` / ``max_tokens`` are terminal (issue #37). An
+        absent or unrecognized reason maps to ``StopReasonCategory.UNKNOWN``.
+
+        Returns:
+            The :class:`StopReasonCategory` for this response's stop reason.
+        """
+        return StopReasonClassifier.categorize(self.get_stop_reason())
 
     def get_additional_model_response_fields(self) -> Optional[Dict[str, Any]]:
         """

--- a/src/bestehorn_llmmanager/bedrock/models/llm_manager_constants.py
+++ b/src/bestehorn_llmmanager/bedrock/models/llm_manager_constants.py
@@ -6,6 +6,8 @@ Contains string constants for JSON field access and configuration values.
 import logging
 from typing import Final
 
+from .stop_reason import StopReasonEnum
+
 
 class ConverseAPIFields:
     """JSON field constants for AWS Bedrock Converse API requests and responses."""
@@ -87,12 +89,20 @@ class ConverseAPIFields:
     ROLE_USER: Final[str] = "user"
     ROLE_ASSISTANT: Final[str] = "assistant"
 
-    # Stop reason values
-    STOP_REASON_END_TURN: Final[str] = "end_turn"
-    STOP_REASON_MAX_TOKENS: Final[str] = "max_tokens"
-    STOP_REASON_STOP_SEQUENCE: Final[str] = "stop_sequence"
-    STOP_REASON_TOOL_USE: Final[str] = "tool_use"
-    STOP_REASON_CONTENT_FILTERED: Final[str] = "content_filtered"
+    # Stop reason values — the complete Bedrock Converse stopReason set (issue #37).
+    # These derive from the canonical StopReasonEnum (single source of truth shared with
+    # StreamingConstants), so core and streaming can never drift.
+    STOP_REASON_END_TURN: Final[str] = StopReasonEnum.END_TURN.value
+    STOP_REASON_MAX_TOKENS: Final[str] = StopReasonEnum.MAX_TOKENS.value
+    STOP_REASON_STOP_SEQUENCE: Final[str] = StopReasonEnum.STOP_SEQUENCE.value
+    STOP_REASON_TOOL_USE: Final[str] = StopReasonEnum.TOOL_USE.value
+    STOP_REASON_CONTENT_FILTERED: Final[str] = StopReasonEnum.CONTENT_FILTERED.value
+    STOP_REASON_GUARDRAIL_INTERVENED: Final[str] = StopReasonEnum.GUARDRAIL_INTERVENED.value
+    STOP_REASON_MALFORMED_MODEL_OUTPUT: Final[str] = StopReasonEnum.MALFORMED_MODEL_OUTPUT.value
+    STOP_REASON_MALFORMED_TOOL_USE: Final[str] = StopReasonEnum.MALFORMED_TOOL_USE.value
+    STOP_REASON_MODEL_CONTEXT_WINDOW_EXCEEDED: Final[str] = (
+        StopReasonEnum.MODEL_CONTEXT_WINDOW_EXCEEDED.value
+    )
 
 
 class LLMManagerConfig:

--- a/src/bestehorn_llmmanager/bedrock/models/stop_reason.py
+++ b/src/bestehorn_llmmanager/bedrock/models/stop_reason.py
@@ -1,0 +1,129 @@
+"""
+Canonical Bedrock Converse ``stopReason`` model.
+
+This is the single source of truth for the Converse API ``stopReason`` values, shared by
+the core ``ConverseAPIFields`` and the streaming ``StreamingConstants`` so the two never
+drift apart (issue #37). It also classifies each stop reason for retry/failover decisions.
+"""
+
+from enum import Enum
+from typing import Optional, Union
+
+
+class StopReasonEnum(str, Enum):
+    """The complete set of AWS Bedrock Converse ``stopReason`` values.
+
+    Matches the ``bedrock-runtime`` ``StopReason`` enum exactly (all nine values). Member
+    names map to the ``STOP_REASON_<NAME>`` constants exposed by ``ConverseAPIFields`` and
+    ``StreamingConstants``.
+    """
+
+    END_TURN = "end_turn"
+    TOOL_USE = "tool_use"
+    MAX_TOKENS = "max_tokens"
+    STOP_SEQUENCE = "stop_sequence"
+    GUARDRAIL_INTERVENED = "guardrail_intervened"
+    CONTENT_FILTERED = "content_filtered"
+    MALFORMED_MODEL_OUTPUT = "malformed_model_output"
+    MALFORMED_TOOL_USE = "malformed_tool_use"
+    MODEL_CONTEXT_WINDOW_EXCEEDED = "model_context_window_exceeded"
+
+
+class StopReasonCategory(str, Enum):
+    """How a stop reason should influence retry/failover decisions.
+
+    - ``TERMINAL``: a normal completion; do not retry (end_turn, tool_use, stop_sequence,
+      max_tokens).
+    - ``RETRY_DIFFERENT_TARGET``: retrying the SAME model/region is futile or undesirable;
+      a different target may succeed. ``model_context_window_exceeded`` (this model's
+      window is too small for the input), ``guardrail_intervened`` and ``content_filtered``
+      (policy outcome that another model/region may treat differently).
+    - ``RETRYABLE``: a transient model glitch where a retry (same or different target) may
+      help — ``malformed_model_output`` / ``malformed_tool_use``.
+    - ``UNKNOWN``: an unrecognized or absent value (forward-compatible; never crashes).
+    """
+
+    TERMINAL = "terminal"
+    RETRY_DIFFERENT_TARGET = "retry_different_target"
+    RETRYABLE = "retryable"
+    UNKNOWN = "unknown"
+
+
+class StopReasonClassifier:
+    """Classifies Bedrock ``stopReason`` values for retry/failover handling (issue #37)."""
+
+    _TERMINAL = frozenset(
+        {
+            StopReasonEnum.END_TURN,
+            StopReasonEnum.TOOL_USE,
+            StopReasonEnum.STOP_SEQUENCE,
+            StopReasonEnum.MAX_TOKENS,
+        }
+    )
+    _RETRY_DIFFERENT_TARGET = frozenset(
+        {
+            StopReasonEnum.MODEL_CONTEXT_WINDOW_EXCEEDED,
+            StopReasonEnum.GUARDRAIL_INTERVENED,
+            StopReasonEnum.CONTENT_FILTERED,
+        }
+    )
+    _RETRYABLE = frozenset(
+        {
+            StopReasonEnum.MALFORMED_MODEL_OUTPUT,
+            StopReasonEnum.MALFORMED_TOOL_USE,
+        }
+    )
+
+    @classmethod
+    def _coerce(cls, reason: Optional[Union[str, StopReasonEnum]]) -> Optional[StopReasonEnum]:
+        """Coerce a raw string / enum / None to a StopReasonEnum, or None if unrecognized."""
+        if reason is None:
+            return None
+        if isinstance(reason, StopReasonEnum):
+            return reason
+        try:
+            return StopReasonEnum(reason)
+        except ValueError:
+            return None
+
+    @classmethod
+    def categorize(cls, reason: Optional[Union[str, StopReasonEnum]]) -> StopReasonCategory:
+        """
+        Categorize a stop reason for retry/failover handling.
+
+        Args:
+            reason: A ``StopReasonEnum``, the raw API string (what
+                ``BedrockResponse.get_stop_reason()`` returns), or None.
+
+        Returns:
+            The :class:`StopReasonCategory`. Unrecognized or absent values map to
+            ``UNKNOWN`` (forward-compatible).
+        """
+        coerced = cls._coerce(reason)
+        if coerced is None:
+            return StopReasonCategory.UNKNOWN
+        if coerced in cls._TERMINAL:
+            return StopReasonCategory.TERMINAL
+        if coerced in cls._RETRY_DIFFERENT_TARGET:
+            return StopReasonCategory.RETRY_DIFFERENT_TARGET
+        if coerced in cls._RETRYABLE:
+            return StopReasonCategory.RETRYABLE
+        return StopReasonCategory.UNKNOWN
+
+    @classmethod
+    def is_terminal(cls, reason: Optional[Union[str, StopReasonEnum]]) -> bool:
+        """True if the stop reason represents a normal completion (no retry warranted)."""
+        return cls.categorize(reason) == StopReasonCategory.TERMINAL
+
+    @classmethod
+    def is_retryable(cls, reason: Optional[Union[str, StopReasonEnum]]) -> bool:
+        """True if a retry (a different target, or a fresh attempt) may help.
+
+        Covers both ``RETRY_DIFFERENT_TARGET`` and ``RETRYABLE``; ``model_context_window_exceeded``
+        is retryable only against a DIFFERENT target (see :meth:`categorize`), not the same
+        model/region with the same oversized input.
+        """
+        return cls.categorize(reason) in (
+            StopReasonCategory.RETRY_DIFFERENT_TARGET,
+            StopReasonCategory.RETRYABLE,
+        )

--- a/src/bestehorn_llmmanager/bedrock/streaming/streaming_constants.py
+++ b/src/bestehorn_llmmanager/bedrock/streaming/streaming_constants.py
@@ -5,6 +5,8 @@ Defines field names, event types, and configuration values for AWS Bedrock strea
 
 from enum import Enum
 
+from ..models.stop_reason import StopReasonEnum
+
 
 class StreamingEventTypes(str, Enum):
     """Enumeration of AWS Bedrock Converse Stream event types."""
@@ -65,13 +67,18 @@ class StreamingConstants:
     FIELD_ORIGINAL_STATUS_CODE = "originalStatusCode"
     FIELD_ORIGINAL_MESSAGE = "originalMessage"
 
-    # Stop Reasons
-    STOP_REASON_END_TURN = "end_turn"
-    STOP_REASON_TOOL_USE = "tool_use"
-    STOP_REASON_MAX_TOKENS = "max_tokens"
-    STOP_REASON_STOP_SEQUENCE = "stop_sequence"
-    STOP_REASON_GUARDRAIL_INTERVENED = "guardrail_intervened"
-    STOP_REASON_CONTENT_FILTERED = "content_filtered"
+    # Stop Reasons — the complete Bedrock Converse stopReason set (issue #37), derived
+    # from the canonical StopReasonEnum so streaming and core (ConverseAPIFields) stay in
+    # lockstep.
+    STOP_REASON_END_TURN = StopReasonEnum.END_TURN.value
+    STOP_REASON_TOOL_USE = StopReasonEnum.TOOL_USE.value
+    STOP_REASON_MAX_TOKENS = StopReasonEnum.MAX_TOKENS.value
+    STOP_REASON_STOP_SEQUENCE = StopReasonEnum.STOP_SEQUENCE.value
+    STOP_REASON_GUARDRAIL_INTERVENED = StopReasonEnum.GUARDRAIL_INTERVENED.value
+    STOP_REASON_CONTENT_FILTERED = StopReasonEnum.CONTENT_FILTERED.value
+    STOP_REASON_MALFORMED_MODEL_OUTPUT = StopReasonEnum.MALFORMED_MODEL_OUTPUT.value
+    STOP_REASON_MALFORMED_TOOL_USE = StopReasonEnum.MALFORMED_TOOL_USE.value
+    STOP_REASON_MODEL_CONTEXT_WINDOW_EXCEEDED = StopReasonEnum.MODEL_CONTEXT_WINDOW_EXCEEDED.value
 
     # Configuration
     DEFAULT_STREAM_TIMEOUT = 300  # seconds

--- a/test/bestehorn_llmmanager/bedrock/models/test_stop_reason.py
+++ b/test/bestehorn_llmmanager/bedrock/models/test_stop_reason.py
@@ -1,0 +1,177 @@
+"""
+Tests for the canonical stop-reason model (issue #37).
+
+`StopReasonEnum` must cover all 9 Bedrock Converse ``stopReason`` values and be the single
+source of truth shared by the core ``ConverseAPIFields`` and the streaming
+``StreamingConstants``. ``StopReasonClassifier`` categorizes each value for retry/failover
+decisions.
+"""
+
+from bestehorn_llmmanager.bedrock.models.llm_manager_constants import ConverseAPIFields
+from bestehorn_llmmanager.bedrock.models.stop_reason import (
+    StopReasonCategory,
+    StopReasonClassifier,
+    StopReasonEnum,
+)
+from bestehorn_llmmanager.bedrock.streaming.streaming_constants import StreamingConstants
+
+# The authoritative Bedrock Converse StopReason enum (boto3 bedrock-runtime service model).
+BEDROCK_STOP_REASONS = {
+    "end_turn",
+    "tool_use",
+    "max_tokens",
+    "stop_sequence",
+    "guardrail_intervened",
+    "content_filtered",
+    "malformed_model_output",
+    "malformed_tool_use",
+    "model_context_window_exceeded",
+}
+
+
+class TestStopReasonEnumCoversBedrock:
+    def test_enum_equals_bedrock_set(self):
+        assert {r.value for r in StopReasonEnum} == BEDROCK_STOP_REASONS
+
+    def test_previously_missing_values_present(self):
+        values = {r.value for r in StopReasonEnum}
+        for v in (
+            "guardrail_intervened",
+            "malformed_model_output",
+            "malformed_tool_use",
+            "model_context_window_exceeded",
+        ):
+            assert v in values
+
+
+class TestCoreAndStreamingUnified:
+    """The core + streaming stop-reason constants derive from the canonical enum."""
+
+    def test_core_constants_match_enum(self):
+        assert ConverseAPIFields.STOP_REASON_END_TURN == StopReasonEnum.END_TURN.value
+        assert ConverseAPIFields.STOP_REASON_MAX_TOKENS == StopReasonEnum.MAX_TOKENS.value
+        assert ConverseAPIFields.STOP_REASON_STOP_SEQUENCE == StopReasonEnum.STOP_SEQUENCE.value
+        assert ConverseAPIFields.STOP_REASON_TOOL_USE == StopReasonEnum.TOOL_USE.value
+        assert (
+            ConverseAPIFields.STOP_REASON_CONTENT_FILTERED == StopReasonEnum.CONTENT_FILTERED.value
+        )
+        # Newly added on the core side:
+        assert (
+            ConverseAPIFields.STOP_REASON_GUARDRAIL_INTERVENED
+            == StopReasonEnum.GUARDRAIL_INTERVENED.value
+        )
+        assert (
+            ConverseAPIFields.STOP_REASON_MALFORMED_MODEL_OUTPUT
+            == StopReasonEnum.MALFORMED_MODEL_OUTPUT.value
+        )
+        assert (
+            ConverseAPIFields.STOP_REASON_MALFORMED_TOOL_USE
+            == StopReasonEnum.MALFORMED_TOOL_USE.value
+        )
+        assert (
+            ConverseAPIFields.STOP_REASON_MODEL_CONTEXT_WINDOW_EXCEEDED
+            == StopReasonEnum.MODEL_CONTEXT_WINDOW_EXCEEDED.value
+        )
+
+    def test_streaming_constants_match_enum(self):
+        assert StreamingConstants.STOP_REASON_END_TURN == StopReasonEnum.END_TURN.value
+        assert (
+            StreamingConstants.STOP_REASON_GUARDRAIL_INTERVENED
+            == StopReasonEnum.GUARDRAIL_INTERVENED.value
+        )
+        # Streaming now also carries the malformed/context values (parity with core):
+        assert (
+            StreamingConstants.STOP_REASON_MALFORMED_MODEL_OUTPUT
+            == StopReasonEnum.MALFORMED_MODEL_OUTPUT.value
+        )
+        assert (
+            StreamingConstants.STOP_REASON_MODEL_CONTEXT_WINDOW_EXCEEDED
+            == StopReasonEnum.MODEL_CONTEXT_WINDOW_EXCEEDED.value
+        )
+
+    def test_core_and_streaming_agree_on_every_shared_value(self):
+        """Every core STOP_REASON_* constant equals the streaming one of the same name."""
+        for enum_member in StopReasonEnum:
+            name = f"STOP_REASON_{enum_member.name}"
+            assert getattr(ConverseAPIFields, name) == getattr(StreamingConstants, name), name
+
+
+class TestStopReasonClassifier:
+    """Retry/failover categorization for each stop reason."""
+
+    def test_terminal_reasons_not_retryable(self):
+        for reason in (
+            StopReasonEnum.END_TURN,
+            StopReasonEnum.TOOL_USE,
+            StopReasonEnum.STOP_SEQUENCE,
+            StopReasonEnum.MAX_TOKENS,
+        ):
+            assert StopReasonClassifier.categorize(reason) == StopReasonCategory.TERMINAL
+            assert StopReasonClassifier.is_terminal(reason)
+            assert not StopReasonClassifier.is_retryable(reason)
+
+    def test_model_context_window_exceeded_retries_different_target(self):
+        reason = StopReasonEnum.MODEL_CONTEXT_WINDOW_EXCEEDED
+        assert StopReasonClassifier.categorize(reason) == StopReasonCategory.RETRY_DIFFERENT_TARGET
+        assert StopReasonClassifier.is_retryable(reason)
+        # It must NOT be classified as a plain same-target retry: a model whose context
+        # window was exceeded will reject the same oversized input again.
+        assert not StopReasonClassifier.is_terminal(reason)
+
+    def test_malformed_reasons_are_retryable(self):
+        for reason in (
+            StopReasonEnum.MALFORMED_MODEL_OUTPUT,
+            StopReasonEnum.MALFORMED_TOOL_USE,
+        ):
+            assert StopReasonClassifier.is_retryable(reason)
+            assert not StopReasonClassifier.is_terminal(reason)
+
+    def test_guardrail_and_content_filtered_categorized(self):
+        for reason in (
+            StopReasonEnum.GUARDRAIL_INTERVENED,
+            StopReasonEnum.CONTENT_FILTERED,
+        ):
+            # These are not normal completion; a different target may behave differently.
+            assert not StopReasonClassifier.is_terminal(reason)
+
+    def test_classifier_accepts_raw_string(self):
+        """categorize() also accepts the raw API string (what get_stop_reason returns)."""
+        assert (
+            StopReasonClassifier.categorize("model_context_window_exceeded")
+            == StopReasonCategory.RETRY_DIFFERENT_TARGET
+        )
+        assert StopReasonClassifier.categorize("end_turn") == StopReasonCategory.TERMINAL
+
+    def test_unknown_value_is_unknown_category(self):
+        """An unrecognized stop reason is categorized UNKNOWN (forward-compatible, not a crash)."""
+        assert StopReasonClassifier.categorize("some_future_reason") == StopReasonCategory.UNKNOWN
+        assert StopReasonClassifier.categorize(None) == StopReasonCategory.UNKNOWN
+
+
+class TestBedrockResponseStopReasonCategory:
+    """BedrockResponse surfaces the canonical category for its raw stop reason."""
+
+    def test_get_stop_reason_category(self):
+        from bestehorn_llmmanager.bedrock.models.bedrock_response import BedrockResponse
+
+        response = BedrockResponse(
+            success=True,
+            response_data={ConverseAPIFields.STOP_REASON: "model_context_window_exceeded"},
+        )
+        assert response.get_stop_reason() == "model_context_window_exceeded"
+        assert response.get_stop_reason_category() == StopReasonCategory.RETRY_DIFFERENT_TARGET
+
+    def test_get_stop_reason_category_terminal(self):
+        from bestehorn_llmmanager.bedrock.models.bedrock_response import BedrockResponse
+
+        response = BedrockResponse(
+            success=True,
+            response_data={ConverseAPIFields.STOP_REASON: "end_turn"},
+        )
+        assert response.get_stop_reason_category() == StopReasonCategory.TERMINAL
+
+    def test_get_stop_reason_category_none_when_absent(self):
+        from bestehorn_llmmanager.bedrock.models.bedrock_response import BedrockResponse
+
+        response = BedrockResponse(success=True, response_data={})
+        assert response.get_stop_reason_category() == StopReasonCategory.UNKNOWN


### PR DESCRIPTION
Closes #37.

## Problem

`stopReason` handling modeled only **5 of the 9** Converse values, and the core (`ConverseAPIFields`) and streaming (`StreamingConstants`) constant lists had **drifted** — streaming had `guardrail_intervened`; neither had `malformed_model_output`, `malformed_tool_use`, or `model_context_window_exceeded`. Retry/failover logic switching on the modeled constants couldn't account for the missing four.

## Fix

- **New canonical `bedrock/models/stop_reason.py`** — `StopReasonEnum` (all 9 values, **verified against the boto3 `bedrock-runtime` service model**), `StopReasonCategory`, and `StopReasonClassifier`.
- **Single source of truth** — `ConverseAPIFields` and `StreamingConstants` now derive every `STOP_REASON_*` constant from `StopReasonEnum`, so core and streaming can never drift again, and both gain the 4 missing values.
- **Retry/failover categorization** (`StopReasonClassifier`):
  - `TERMINAL`: `end_turn`, `tool_use`, `stop_sequence`, `max_tokens`
  - `RETRY_DIFFERENT_TARGET`: `model_context_window_exceeded` (don't blindly retry the same model with the same oversized input), `guardrail_intervened`, `content_filtered`
  - `RETRYABLE`: `malformed_model_output`, `malformed_tool_use`
  - `UNKNOWN`: unrecognized/absent (forward-compatible — never crashes)
- **`BedrockResponse.get_stop_reason_category()`** surfaces the typed category so callers branch on intent, not raw strings.

## Scope note (checklist item 3)

The Converse `stopReason` arrives in a **successful (HTTP 200)** response body, while the retry loop (`retry_manager.execute_with_retry`) only retries on **exceptions**. Wiring the success path to re-drive retries on a bad stop reason would change success-path control flow (latency/cost) for **all** callers — disproportionate to a "complete the coverage" bug and risky without specified semantics. So that wiring is **deliberately deferred**; the canonical classifier is the correct, tested decision unit and makes the wiring a one-liner when desired. Nothing acts on a non-`end_turn` stop reason post-success today, so this change is **purely additive — no behavior regression**.

## Checklist
- [x] Add the 4 missing stop-reason constants to the canonical set
- [x] Unify core + streaming stop-reason constants (single source of truth)
- [x] Classify `model_context_window_exceeded` / `malformed_*` for retry/failover decisions (canonical classifier + typed category; success-path wiring documented as deferred)
- [x] Tests for each stop reason's handling

## Proof (local, worktree venv)

- `ruff format --check` ✓, `ruff check` ✓, `mypy --exclude="_version" src/` ✓ (101 files)
- 14 new tests in `test_stop_reason.py` (enum == Bedrock set; core==streaming for every member; classifier categories; `BedrockResponse` category incl. unknown/absent).
- Full unit suite `pytest test/bestehorn_llmmanager/ -n auto` → **2649 passed, 7 skipped, 0 failed**