### PR TITLE
ci: add release smoke-test that installs and imports the built artifact (#46)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,22 @@ jobs:
       run: |
         twine check dist/*
         ls -la dist/
-    
+
+    - name: Smoke-test the built wheel (clean env)
+      # Install the freshly-built wheel into a clean venv (no editable install, repo src/
+      # not on sys.path) and run the release smoke test, so packaging regressions —
+      # a missing runtime dependency, a dropped package-data file, or an import error
+      # only seen from an installed wheel — are caught on PRs, not only at release
+      # (issue #46).
+      run: |
+        set -euo pipefail
+        cp scripts/release_smoke_test.py "$RUNNER_TEMP/release_smoke_test.py"
+        python -m venv "$RUNNER_TEMP/smoke-env"
+        "$RUNNER_TEMP/smoke-env/bin/python" -m pip install --upgrade pip
+        "$RUNNER_TEMP/smoke-env/bin/python" -m pip install dist/*.whl
+        cd "$RUNNER_TEMP"
+        ./smoke-env/bin/python release_smoke_test.py
+
     - name: Upload artifacts
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,26 +11,26 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-    
+
     steps:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Required for setuptools-scm to access git history and tags
-    
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
-    
+
     - name: Run tests
       run: |
         pytest test/bestehorn_llmmanager/ -v --cov=bestehorn_llmmanager --cov-report=xml --ignore=test/integration/
-    
+
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.11'
       uses: codecov/codecov-action@v7
@@ -40,30 +40,30 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
-  build-and-publish:
+  build:
     needs: test
     runs-on: ubuntu-latest
-    permissions:
-      # Required for PyPI Trusted Publishing
-      id-token: write
-      # Required for creating GitHub releases
-      contents: write
-    
+    outputs:
+      # Whether setuptools-scm produced a clean (publishable) release version. The
+      # publish job reads this to decide Test PyPI / PyPI publication.
+      is_release_version: ${{ steps.version-check.outputs.is_release_version }}
+      version: ${{ steps.version-check.outputs.version }}
+
     steps:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Required for setuptools-scm to access git history and tags
-    
+
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: '3.11'
-    
+
     - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade build twine pkginfo setuptools-scm
-    
+
     - name: Verify setuptools-scm before build
       run: |
         echo "=== setuptools-scm Diagnostics ==="
@@ -71,7 +71,7 @@ jobs:
         git status
         git log --oneline -5
         git tag --list | tail -10
-        
+
         echo "--- setuptools-scm version detection ---"
         python -c "
         try:
@@ -83,26 +83,26 @@ jobs:
             import traceback
             traceback.print_exc()
         "
-    
+
     - name: Build package with diagnostics
       run: |
         echo "=== Build Process Diagnostics ==="
         echo "Building package..."
         python -m build --verbose
         echo "=== Build completed ==="
-    
+
     - name: Inspect built package metadata
       run: |
         echo "=== Package Metadata Investigation ==="
         echo "--- Contents of dist/ directory ---"
         ls -la dist/
-        
+
         echo "--- Wheel file contents ---"
         python -c "
         import os
         import zipfile
         import glob
-        
+
         wheel_files = glob.glob('dist/*.whl')
         if wheel_files:
             wheel_file = wheel_files[0]
@@ -111,11 +111,11 @@ jobs:
                 print('Wheel contents:')
                 for name in sorted(zf.namelist()):
                     print(f'  {name}')
-                
+
                 # Look for metadata files
                 metadata_files = [n for n in zf.namelist() if 'METADATA' in n or 'metadata' in n.lower()]
                 print(f'Metadata files found: {metadata_files}')
-                
+
                 for meta_file in metadata_files:
                     print(f'--- Contents of {meta_file} ---')
                     try:
@@ -128,12 +128,12 @@ jobs:
         else:
             print('No wheel files found!')
         "
-        
+
         echo "--- Testing pkginfo on built wheel ---"
         python -c "
         import pkginfo
         import glob
-        
+
         wheel_files = glob.glob('dist/*.whl')
         if wheel_files:
             wheel_file = wheel_files[0]
@@ -150,13 +150,13 @@ jobs:
                 import traceback
                 traceback.print_exc()
         "
-    
+
     - name: Check package
       run: |
         echo "=== Final Package Check ==="
-        twine check dist/* || echo "Twine check failed as expected"
+        twine check dist/*
         ls -la dist/
-    
+
     - name: Check if version is clean release (no dev/local identifiers)
       id: version-check
       run: |
@@ -164,7 +164,7 @@ jobs:
         # Get the version from setuptools-scm
         VERSION=$(python -c "from setuptools_scm import get_version; print(get_version())")
         echo "Generated version: $VERSION"
-        
+
         # Check if version contains dev or local identifiers
         if [[ "$VERSION" == *"dev"* ]] || [[ "$VERSION" == *"+"* ]]; then
           echo "❌ Development version detected: $VERSION"
@@ -176,36 +176,125 @@ jobs:
           echo "is_release_version=true" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
         fi
-    
+
+    - name: Upload built distributions
+      uses: actions/upload-artifact@v7
+      with:
+        name: release-dist
+        path: dist/
+
+  # Install the built artifact into a CLEAN environment (no editable install, repo src/
+  # not on sys.path) and run the smoke test, for both the wheel and the sdist, across a
+  # representative Python subset (min + max supported). Gates the publish job (issue #46):
+  # a broken-but-installable artifact (missing runtime dep, dropped package-data, import
+  # error only seen from an installed wheel) cannot reach PyPI.
+  smoke-test:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ['3.10', '3.14']
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        # Sparse: we only need the smoke-test script, NOT the package src/ (which must
+        # not shadow the installed artifact). The script is copied out before running.
+        sparse-checkout: |
+          scripts/release_smoke_test.py
+        sparse-checkout-cone-mode: false
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Download built distributions
+      uses: actions/download-artifact@v7
+      with:
+        name: release-dist
+        path: dist/
+
+    - name: Smoke-test the built wheel (clean env)
+      run: |
+        set -euo pipefail
+        # Move the smoke script out of the repo so the working dir has no src/ on sys.path.
+        cp scripts/release_smoke_test.py "$RUNNER_TEMP/release_smoke_test.py"
+        python -m venv "$RUNNER_TEMP/wheel-env"
+        "$RUNNER_TEMP/wheel-env/bin/python" -m pip install --upgrade pip
+        "$RUNNER_TEMP/wheel-env/bin/python" -m pip install dist/*.whl
+        VERSION="${{ needs.build.outputs.version }}"
+        cd "$RUNNER_TEMP"
+        if [ "${{ needs.build.outputs.is_release_version }}" = "true" ]; then
+          ./wheel-env/bin/python release_smoke_test.py --expected-version "$VERSION"
+        else
+          ./wheel-env/bin/python release_smoke_test.py
+        fi
+
+    - name: Smoke-test the built sdist (clean env)
+      run: |
+        set -euo pipefail
+        cp scripts/release_smoke_test.py "$RUNNER_TEMP/release_smoke_test.py"
+        python -m venv "$RUNNER_TEMP/sdist-env"
+        "$RUNNER_TEMP/sdist-env/bin/python" -m pip install --upgrade pip
+        "$RUNNER_TEMP/sdist-env/bin/python" -m pip install dist/*.tar.gz
+        VERSION="${{ needs.build.outputs.version }}"
+        cd "$RUNNER_TEMP"
+        if [ "${{ needs.build.outputs.is_release_version }}" = "true" ]; then
+          ./sdist-env/bin/python release_smoke_test.py --expected-version "$VERSION"
+        else
+          ./sdist-env/bin/python release_smoke_test.py
+        fi
+
+  publish:
+    needs: [build, smoke-test]
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for PyPI Trusted Publishing
+      id-token: write
+      # Required for creating GitHub releases
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Download built distributions
+      uses: actions/download-artifact@v7
+      with:
+        name: release-dist
+        path: dist/
+
     - name: Publish to Test PyPI
-      if: steps.version-check.outputs.is_release_version == 'true'
+      if: needs.build.outputs.is_release_version == 'true'
       uses: pypa/gh-action-pypi-publish@v1.12.2
       with:
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true
         attestations: false
         verbose: true
-    
+
     - name: Skip Test PyPI (Development Version)
-      if: steps.version-check.outputs.is_release_version == 'false'
+      if: needs.build.outputs.is_release_version == 'false'
       run: |
-        echo "⚠️ Skipping Test PyPI publication for development version: ${{ steps.version-check.outputs.version }}"
+        echo "⚠️ Skipping Test PyPI publication for development version: ${{ needs.build.outputs.version }}"
         echo "This is likely because the workflow is running on a commit after the tag."
         echo "To publish a release, ensure the workflow runs exactly on the tagged commit."
-    
+
     - name: Publish to PyPI
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && steps.version-check.outputs.is_release_version == 'true'
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && needs.build.outputs.is_release_version == 'true'
       uses: pypa/gh-action-pypi-publish@v1.12.2
       with:
         attestations: false
         verbose: true
-    
+
     - name: Skip PyPI (Development Version)
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && steps.version-check.outputs.is_release_version == 'false'
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && needs.build.outputs.is_release_version == 'false'
       run: |
-        echo "⚠️ Skipping PyPI publication for development version: ${{ steps.version-check.outputs.version }}"
+        echo "⚠️ Skipping PyPI publication for development version: ${{ needs.build.outputs.version }}"
         echo "This suggests a problem with git tag detection or the workflow trigger."
-    
+
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1
       with:

--- a/scripts/release_smoke_test.py
+++ b/scripts/release_smoke_test.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Release smoke test for the bestehorn-llmmanager built artifact (issue #46).
+
+This script verifies that an **installed** ``bestehorn_llmmanager`` (a wheel or sdist
+installed into a clean environment — NOT the editable source tree) is healthy:
+
+1. the package imports and exposes a non-empty ``__version__`` (optionally matching an
+   expected release version);
+2. every name in ``__all__`` is importable from the top-level package;
+3. core objects construct with no AWS credentials or network access; and
+4. the bundled catalog JSON ships and loads offline through the public loader.
+
+It is run by ``.github/workflows/release.yml`` (gating the prod-PyPI publish) and by the
+``ci.yml`` build job (catching packaging regressions on PRs). Run it from a directory that
+is NOT the repo root, against a venv where the built artifact is installed::
+
+    python release_smoke_test.py --expected-version 0.8.5
+
+Exit code 0 = all checks passed; non-zero = a check failed (the failure is printed).
+"""
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Optional
+
+
+class SmokeTestError(Exception):
+    """Raised when a release smoke-test check fails."""
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Outcome of a single smoke check."""
+
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+def assert_installed_not_editable(module_file: Optional[str] = None) -> None:
+    """Verify the imported package is a real install, not the repo ``src/`` tree.
+
+    The whole point of a release smoke test is to exercise the *installed artifact*. An
+    editable install (or running with the repo ``src/`` on ``sys.path``) would silently
+    test the source tree instead, defeating the smoke test. We reject any import whose
+    file lives under a ``src/`` directory or an ``__editable__``/``.pth`` shim.
+
+    Args:
+        module_file: Path to the imported package's ``__init__.py``. Defaults to the
+            installed ``bestehorn_llmmanager.__file__``.
+
+    Raises:
+        SmokeTestError: If the package appears to be imported from a repo source tree
+            or an editable install rather than an installed artifact.
+    """
+    if module_file is None:
+        import bestehorn_llmmanager
+
+        module_file = bestehorn_llmmanager.__file__ or ""
+
+    resolved = Path(module_file).resolve()
+    parts = {p.lower() for p in resolved.parts}
+
+    if "src" in parts:
+        raise SmokeTestError(
+            f"Package imported from a 'src/' tree ({resolved}); the smoke test must run "
+            f"against an INSTALLED artifact, not the editable source tree."
+        )
+    if "__editable__" in resolved.name or "__editable__" in str(resolved):
+        raise SmokeTestError(f"Package appears to be an editable install ({resolved}).")
+    if "site-packages" not in parts and "dist-packages" not in parts:
+        # Not fatal on every layout, but in CI the install goes to site-packages; warn loudly.
+        print(
+            f"WARNING: imported package path is not under site-packages ({resolved}). "
+            f"Ensure this runs against an installed artifact in a clean environment.",
+            file=sys.stderr,
+        )
+
+
+def check_import_and_version(expected_version: Optional[str] = None) -> str:
+    """Import the package and validate ``__version__``.
+
+    Args:
+        expected_version: If provided, the package ``__version__`` must equal it.
+
+    Returns:
+        The imported ``__version__`` string.
+
+    Raises:
+        SmokeTestError: If the import fails, the version is empty, or it does not match
+            ``expected_version``.
+    """
+    try:
+        import bestehorn_llmmanager
+    except Exception as exc:  # noqa: BLE001 - surface any import failure as a smoke failure
+        raise SmokeTestError(f"`import bestehorn_llmmanager` failed: {exc}") from exc
+
+    version = getattr(bestehorn_llmmanager, "__version__", "")
+    if not isinstance(version, str) or not version:
+        raise SmokeTestError(f"__version__ is empty or not a string: {version!r}")
+
+    if expected_version is not None and version != expected_version:
+        raise SmokeTestError(
+            f"__version__ {version!r} does not match expected release version {expected_version!r}"
+        )
+    return version
+
+
+def check_public_surface() -> List[str]:
+    """Import every name declared in the package's ``__all__``.
+
+    Returns:
+        The list of successfully imported public names.
+
+    Raises:
+        SmokeTestError: If ``__all__`` is missing/empty or any name is not importable.
+    """
+    import bestehorn_llmmanager
+
+    public_names = getattr(bestehorn_llmmanager, "__all__", None)
+    if not public_names:
+        raise SmokeTestError("Package __all__ is missing or empty.")
+
+    missing = [name for name in public_names if not hasattr(bestehorn_llmmanager, name)]
+    if missing:
+        raise SmokeTestError(f"Names in __all__ not importable from the package: {missing}")
+    return list(public_names)
+
+
+def check_no_aws_construction() -> None:
+    """Construct core objects that must work with no AWS credentials or network.
+
+    Raises:
+        SmokeTestError: If any no-AWS construction path fails.
+    """
+    try:
+        from bestehorn_llmmanager import (
+            RolesEnum,
+            create_user_message,
+            get_all_regions,
+        )
+
+        # MessageBuilder fluent build (pure, no AWS).
+        message = create_user_message().add_text("smoke test").build()
+        if not message:
+            raise SmokeTestError("create_user_message().add_text(...).build() returned falsy.")
+
+        # Enum access.
+        _ = RolesEnum.USER
+
+        # Region utility (static data, no network).
+        regions = get_all_regions()
+        if not regions:
+            raise SmokeTestError("get_all_regions() returned no regions.")
+    except SmokeTestError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - any failure here is a smoke failure
+        raise SmokeTestError(f"No-AWS construction failed: {exc}") from exc
+
+
+def check_bundled_catalog_loads() -> None:
+    """Load the bundled catalog JSON offline via the public loader.
+
+    A packaging gap that dropped ``bedrock/package_data/bedrock_catalog_bundled.json``
+    would install cleanly but fail here — exactly the class of defect this smoke test
+    exists to catch.
+
+    Raises:
+        SmokeTestError: If the bundled catalog cannot be located or loaded.
+    """
+    try:
+        from bestehorn_llmmanager.bedrock.catalog.bundled_loader import BundledDataLoader
+
+        catalog = BundledDataLoader.load_bundled_catalog()
+        if catalog is None:
+            raise SmokeTestError("BundledDataLoader.load_bundled_catalog() returned None.")
+    except SmokeTestError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - any failure here is a smoke failure
+        raise SmokeTestError(
+            f"Bundled catalog failed to load from the installed package: {exc}"
+        ) from exc
+
+
+def run_smoke_checks(expected_version: Optional[str] = None) -> List[CheckResult]:
+    """Run all smoke checks in order, returning one CheckResult per check.
+
+    The first failing check raises ``SmokeTestError`` (fail fast), so a returned list
+    means every check passed.
+
+    Args:
+        expected_version: Optional release version the package must report.
+
+    Returns:
+        A list of passed :class:`CheckResult` (one per check).
+
+    Raises:
+        SmokeTestError: On the first failing check.
+    """
+    assert_installed_not_editable()
+
+    checks: List[tuple[str, Callable[[], object]]] = [
+        ("import", lambda: check_import_and_version(expected_version=expected_version)),
+        ("public_surface", check_public_surface),
+        ("no_aws_construction", check_no_aws_construction),
+        ("bundled_catalog", check_bundled_catalog_loads),
+    ]
+
+    results: List[CheckResult] = []
+    for name, fn in checks:
+        fn()
+        results.append(CheckResult(name=name, passed=True))
+        print(f"  [PASS] {name}")
+    return results
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """CLI entry point. Returns 0 if all checks pass, 1 otherwise."""
+    parser = argparse.ArgumentParser(description="Release smoke test for bestehorn-llmmanager.")
+    parser.add_argument(
+        "--expected-version",
+        default=None,
+        help="Release version the installed package must report (e.g. 0.8.5).",
+    )
+    parser.add_argument(
+        "--skip-install-check",
+        action="store_true",
+        help="Skip the installed-not-editable guard (for local invocation from a venv).",
+    )
+    args = parser.parse_args(argv)
+
+    print("Running release smoke test for bestehorn_llmmanager...")
+    try:
+        if args.skip_install_check:
+            # Run the checks without the clean-env guard (local convenience only).
+            check_import_and_version(expected_version=args.expected_version)
+            print("  [PASS] import")
+            check_public_surface()
+            print("  [PASS] public_surface")
+            check_no_aws_construction()
+            print("  [PASS] no_aws_construction")
+            check_bundled_catalog_loads()
+            print("  [PASS] bundled_catalog")
+        else:
+            run_smoke_checks(expected_version=args.expected_version)
+    except SmokeTestError as exc:
+        print(f"\nSMOKE TEST FAILED: {exc}", file=sys.stderr)
+        return 1
+
+    print("\nSMOKE TEST PASSED: installed artifact is importable and healthy.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_release_smoke.py
+++ b/test/test_release_smoke.py
@@ -1,0 +1,109 @@
+"""
+Tests for the release smoke-test script (issue #46).
+
+`scripts/release_smoke_test.py` runs against an INSTALLED `bestehorn_llmmanager` (in CI it
+runs in a clean env where only the installed wheel/sdist is importable) and verifies the
+package imports, exposes its public surface, constructs no-AWS objects, and loads its
+bundled catalog data. These tests exercise the script's check functions directly (the test
+environment has the package importable via the editable install, which is sufficient to
+prove the check logic; the clean-env guard is unit-tested separately with a fake module).
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# Load the script as a module by path (it lives in scripts/, not in the package).
+_SCRIPT = Path(__file__).parent.parent / "scripts" / "release_smoke_test.py"
+_spec = importlib.util.spec_from_file_location("release_smoke_test", _SCRIPT)
+assert _spec and _spec.loader
+release_smoke_test = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(release_smoke_test)
+
+
+class TestSmokeChecksPassOnInstalledPackage:
+    """The individual smoke checks succeed against the importable package."""
+
+    def test_check_import_and_version(self):
+        version = release_smoke_test.check_import_and_version()
+        assert isinstance(version, str)
+        assert version  # non-empty
+
+    def test_check_import_and_version_matches_expected(self):
+        version = release_smoke_test.check_import_and_version()
+        # When an expected version is supplied and matches, it must not raise.
+        release_smoke_test.check_import_and_version(expected_version=version)
+
+    def test_check_import_and_version_rejects_mismatch(self):
+        with pytest.raises(release_smoke_test.SmokeTestError):
+            release_smoke_test.check_import_and_version(expected_version="999.999.999")
+
+    def test_check_public_surface(self):
+        """Every name in __all__ is importable from the top-level package."""
+        imported = release_smoke_test.check_public_surface()
+        assert "LLMManager" in imported
+        assert "MessageBuilder" in imported
+        assert "VideoFormatEnum" in imported
+
+    def test_check_no_aws_construction(self):
+        """Constructing message-builder objects / enums / regions needs no AWS or network."""
+        release_smoke_test.check_no_aws_construction()  # must not raise
+
+    def test_check_bundled_catalog_loads(self):
+        """The bundled catalog JSON loads offline via the public loader."""
+        release_smoke_test.check_bundled_catalog_loads()  # must not raise
+
+    def test_run_smoke_checks_all_pass(self, monkeypatch):
+        """The aggregate runner returns a passed CheckResult per check.
+
+        The test environment is an editable install, so the clean-env guard would
+        (correctly) reject it; we bypass only that guard here and assert the four
+        functional checks all pass. The guard itself is covered by TestCleanEnvGuard.
+        """
+        monkeypatch.setattr(release_smoke_test, "assert_installed_not_editable", lambda: None)
+        results = release_smoke_test.run_smoke_checks()
+        names = {r.name for r in results}
+        assert {"import", "public_surface", "no_aws_construction", "bundled_catalog"} <= names
+        assert all(r.passed for r in results)
+
+
+class TestCleanEnvGuard:
+    """The clean-env guard detects an editable / repo-src import."""
+
+    def test_rejects_module_loaded_from_repo_src(self, tmp_path):
+        """A module whose __file__ is under a repo `src/` tree must be rejected."""
+        fake_src = tmp_path / "src" / "bestehorn_llmmanager" / "__init__.py"
+        fake_src.parent.mkdir(parents=True)
+        fake_src.write_text("")
+        with pytest.raises(release_smoke_test.SmokeTestError):
+            release_smoke_test.assert_installed_not_editable(module_file=str(fake_src))
+
+    def test_accepts_module_loaded_from_site_packages(self, tmp_path):
+        """A module under a site-packages path is accepted (installed artifact)."""
+        sp = tmp_path / "venv" / "lib" / "site-packages" / "bestehorn_llmmanager" / "__init__.py"
+        sp.parent.mkdir(parents=True)
+        sp.write_text("")
+        # Must not raise.
+        release_smoke_test.assert_installed_not_editable(module_file=str(sp))
+
+
+class TestCliEntryPoint:
+    """The script's main() returns 0 on success and is invocable."""
+
+    def test_main_returns_zero_on_success(self):
+        # --skip-install-check runs the functional checks without the clean-env guard,
+        # which is the correct mode for this editable test environment.
+        rc = release_smoke_test.main(argv=["--skip-install-check"])
+        assert rc == 0
+
+    def test_main_rejects_version_mismatch(self):
+        rc = release_smoke_test.main(
+            argv=["--skip-install-check", "--expected-version", "999.999.999"]
+        )
+        assert rc != 0
+
+    def test_main_rejects_editable_install_without_skip(self):
+        """Without --skip-install-check, main() fails in this editable env (guard fires)."""
+        rc = release_smoke_test.main(argv=[])
+        assert rc != 0


### PR DESCRIPTION
Closes #46.

## Problem

The release workflow published to PyPI without ever installing the built wheel/sdist into a clean environment and importing the package. The CI test matrix runs against the editable source tree (`pip install -e .`), keeping `src/` on `sys.path`, so it never exercises the installed-artifact path. A broken-but-installable artifact — a missing runtime dependency, a `MANIFEST.in`/package-data gap that drops the bundled catalog JSON, or an import error only seen from an installed wheel — would reach PyPI and only be caught by downstream consumers.

## What this adds

**`scripts/release_smoke_test.py`** — against an **installed** `bestehorn_llmmanager` it asserts:
1. `import bestehorn_llmmanager` + non-empty `__version__` (optionally `== --expected-version`);
2. every name in `__all__` is importable from the top package;
3. no-AWS construction works (`create_user_message().add_text().build()`, `RolesEnum.USER`, `get_all_regions()`);
4. the bundled catalog JSON loads offline via `BundledDataLoader.load_bundled_catalog()`.

It **guards against running on the editable/repo-`src` tree** (asserts the import is not under a `src/` dir), so it can only validate a real install.

**`release.yml`** — restructured `test → build → smoke-test → publish`:
- `build` uploads `dist/` and exposes the setuptools-scm clean-version decision as job outputs.
- `smoke-test` (matrix **3.10 + 3.14**) downloads `dist/`, installs the **wheel** and the **sdist** into fresh venvs in `$RUNNER_TEMP` (repo `src/` not on `sys.path`; sparse-checkout pulls only the smoke script), and runs the script.
- `publish` (`needs: [build, smoke-test]`) does Test PyPI → prod PyPI → GitHub Release exactly as before, so **a broken artifact cannot reach prod PyPI**.
- Also **hardened the `twine check`** (removed the `|| echo …` that swallowed a non-zero exit — the adjacent observation #46 noted).

**`ci.yml`** — the `build` job additionally installs its built wheel into a clean temp-dir venv and runs the smoke script, catching packaging regressions **on PRs**, not only at release.

## Trusted Publishing safety

PyPI Trusted Publishing matches on repo + workflow **filename** (`release.yml`, unchanged) + optional environment (none used) — **not** the job name. Renaming `build-and-publish` → `publish` while keeping `id-token: write` + the `refs/tags`/clean-version guards preserves the OIDC publish. All artifact actions aligned to v7 (download ↔ upload).

## Open questions (resolved; see spec decision log)

- Artifact source = **local `dist/`** (deterministic; no Test-PyPI propagation-timing/retry dependency).
- Smoke **both** wheel and sdist (sdist catches MANIFEST/package-data gaps).
- Python subset = **min+max** (3.10, 3.14).
- **Yes**, assert the bundled catalog loads offline (the dropped-package-data failure mode #46 cites).

## Proof (local)

- Clean-env smoke (fresh venv outside the repo) for the **wheel** and the **sdist** — both exit 0 with all four checks PASS (`--expected-version 0.8.5`).
- 12 unit tests for the script logic (`test/test_release_smoke.py`) pass.
- `ruff format --check` ✓, `ruff check` ✓, `mypy --exclude="_version" src/` ✓. No `src/` runtime code changed.

CI on this PR is the authoritative gate; its `build` job now exercises the new smoke step.