### PR TITLE
Add typed get_content_blocks iterator for all response modalities (#41)

### DIFF
--- a/docs/forLLMConsumption.md
+++ b/docs/forLLMConsumption.md
@@ -692,10 +692,24 @@ response = manager.converse(messages=[...])
 
 # Basic response information
 success = response.success                                # Boolean: Request success status
-content = response.get_content()                          # String: Main text content
+content = response.get_content()                          # String: Main text content (joins text blocks)
 usage = response.get_usage()                             # Dict: Token usage information
 metrics = response.get_metrics()                         # Dict: Performance metrics
 stop_reason = response.get_stop_reason()                 # String: Why generation stopped
+
+# Typed content-block iteration (all modalities)
+# get_content_blocks() is the general accessor: it returns the ordered list of typed
+# content blocks (text, toolUse, reasoningContent, image, citationsContent, ...) so you
+# can handle any modality without touching the raw response dict. get_content() and the
+# type-specific accessors below are all built on top of it.
+blocks = response.get_content_blocks()                   # Optional[List[dict]]: all blocks in order (None if unavailable)
+
+from bestehorn_llmmanager import ResponseContentType
+tool_blocks = response.get_content_blocks_by_type(       # List[dict]: blocks of one type
+    content_type=ResponseContentType.TOOL_USE            # accepts the enum or the raw key "toolUse"
+)
+text_parts = response.get_text_blocks()                  # List[str]: the text strings, in order
+images = response.get_image_blocks()                     # List[dict]: ImageBlock payloads ({"format","source"})
 
 # Token usage accessor methods (recommended)
 input_tokens = response.get_input_tokens()               # Int: Input tokens used

--- a/src/bestehorn_llmmanager/__init__.py
+++ b/src/bestehorn_llmmanager/__init__.py
@@ -39,6 +39,9 @@ For detailed documentation, see the documentation in the docs/ directory.
 from .bedrock.discovery import BedrockRegionDiscovery
 from .bedrock.models.aws_regions import AWSRegions, get_all_regions
 
+# Response content-block typing (typed iteration over response modalities)
+from .bedrock.models.content_block_types import ResponseContentType
+
 # Configuration dataclasses
 from .bedrock.models.llm_manager_structures import Boto3Config
 
@@ -99,6 +102,8 @@ __all__ = [
     "DocumentFormatEnum",
     "VideoFormatEnum",
     "DetectionMethodEnum",
+    # Response content-block typing
+    "ResponseContentType",
     # Region utilities
     "BedrockRegionDiscovery",
     "get_all_regions",

--- a/src/bestehorn_llmmanager/bedrock/models/bedrock_response.py
+++ b/src/bestehorn_llmmanager/bedrock/models/bedrock_response.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from .content_block_types import ResponseContentType
 from .llm_manager_constants import ConverseAPIFields
 from .llm_manager_structures import RequestAttempt, ValidationAttempt
 from .stop_reason import StopReasonCategory, StopReasonClassifier
@@ -59,12 +60,28 @@ class BedrockResponse:
     original_additional_fields: Optional[Dict[str, Any]] = None
     final_additional_fields: Optional[Dict[str, Any]] = None
 
-    def get_content(self) -> Optional[str]:
+    def get_content_blocks(self) -> Optional[List[Any]]:
         """
-        Extract the main text content from the response.
+        Get the ordered list of typed content blocks from the response message.
+
+        This is the general response-content accessor: it returns every content block
+        from the assistant's message — text, ``toolUse``, ``reasoningContent``,
+        ``image``, ``citationsContent``, and any other ``ContentBlock`` union member —
+        in the order the model produced them, so callers can handle any modality
+        without hand-navigating the raw response dictionary. The type-specific
+        accessors (:meth:`get_text_blocks`, :meth:`get_image_blocks`,
+        :meth:`get_content_blocks_by_type`) and the text convenience
+        :meth:`get_content` are all built on top of this iterator.
+
+        The returned list is a shallow copy, so mutating it does not affect the
+        underlying ``response_data``. Individual block dicts are not copied.
 
         Returns:
-            The text content from the assistant's response, None if not available
+            The ordered list of content blocks, or ``None`` if the response was
+            unsuccessful, has no response data, or has no content list.
+
+        Reference:
+            https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlock.html
         """
         if not self.success or not self.response_data:
             return None
@@ -72,18 +89,90 @@ class BedrockResponse:
         try:
             output = self.response_data.get(ConverseAPIFields.OUTPUT, {})
             message = output.get(ConverseAPIFields.MESSAGE, {})
-            content_blocks = message.get(ConverseAPIFields.CONTENT, [])
-
-            # Extract text from all content blocks
-            text_parts = []
-            for block in content_blocks:
-                if isinstance(block, dict) and ConverseAPIFields.TEXT in block:
-                    text_parts.append(block[ConverseAPIFields.TEXT])
-
-            return "\n".join(text_parts) if text_parts else None
-
+            content_blocks = message.get(ConverseAPIFields.CONTENT, None)
         except (KeyError, TypeError, AttributeError):
             return None
+
+        if not isinstance(content_blocks, list):
+            return None
+
+        return list(content_blocks)
+
+    def get_content_blocks_by_type(
+        self, content_type: Union[ResponseContentType, str]
+    ) -> List[Any]:
+        """
+        Get all content blocks of a single type, in order.
+
+        Filters the result of :meth:`get_content_blocks` to the blocks whose
+        discriminating union key matches ``content_type``.
+
+        Args:
+            content_type: The block type to keep, either a :class:`ResponseContentType`
+                or its raw string key (e.g. ``"text"``, ``"toolUse"``, ``"image"``).
+
+        Returns:
+            The matching blocks in order; an empty list if there are none or if the
+            response has no content blocks.
+        """
+        target = (
+            content_type
+            if isinstance(content_type, ResponseContentType)
+            else ResponseContentType.from_block(block={str(content_type): None})
+        )
+
+        blocks = self.get_content_blocks()
+        if not blocks:
+            return []
+
+        return [
+            block
+            for block in blocks
+            if isinstance(block, dict) and ResponseContentType.from_block(block=block) is target
+        ]
+
+    def get_text_blocks(self) -> List[str]:
+        """
+        Get the text strings from all text content blocks, in order.
+
+        Returns:
+            The ordered list of text strings; an empty list if the response has no
+            text blocks.
+        """
+        return [
+            block[ConverseAPIFields.TEXT]
+            for block in self.get_content_blocks_by_type(content_type=ResponseContentType.TEXT)
+        ]
+
+    def get_image_blocks(self) -> List[Dict[str, Any]]:
+        """
+        Get the image payloads from all image content blocks, in order.
+
+        Each returned item is the value under the block's ``image`` key — an
+        ``ImageBlock`` (``{"format": ..., "source": ...}``) — not the wrapping block.
+
+        Returns:
+            The ordered list of image payloads; an empty list if the response has no
+            image blocks.
+        """
+        return [
+            block[ConverseAPIFields.IMAGE]
+            for block in self.get_content_blocks_by_type(content_type=ResponseContentType.IMAGE)
+        ]
+
+    def get_content(self) -> Optional[str]:
+        """
+        Extract the main text content from the response.
+
+        Joins every text content block with newlines. Built on
+        :meth:`get_text_blocks` (and thus :meth:`get_content_blocks`), so non-text
+        modalities are ignored here but reachable through the typed accessors.
+
+        Returns:
+            The joined text content from the assistant's response, None if not available
+        """
+        text_parts = self.get_text_blocks()
+        return "\n".join(text_parts) if text_parts else None
 
     def get_usage(self) -> Optional[Dict[str, int]]:
         """

--- a/src/bestehorn_llmmanager/bedrock/models/content_block_types.py
+++ b/src/bestehorn_llmmanager/bedrock/models/content_block_types.py
@@ -1,0 +1,105 @@
+"""
+Typed content-block classification for Bedrock Converse responses.
+
+Defines :class:`ResponseContentType`, an enumeration of the member kinds of the Bedrock
+Converse ``ContentBlock`` union, plus a classifier that maps a raw response content-block
+dict to its type. This is the type vocabulary used by
+:meth:`BedrockResponse.get_content_blocks` and the type-specific accessors built on it,
+so callers can handle any modality (text, tool use, reasoning, image, citations, ...)
+without hand-navigating the raw response dictionary.
+
+Reference: AWS Bedrock Runtime ``ContentBlock`` union
+https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlock.html
+"""
+
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from .llm_manager_constants import ConverseAPIFields
+
+
+class ResponseContentType(str, Enum):
+    """
+    Enumeration of Bedrock Converse ``ContentBlock`` union member kinds.
+
+    Each value is the JSON key that identifies the union member within a single content
+    block (a ``ContentBlock`` is a union, so exactly one of these keys is present in a
+    well-formed block). ``UNKNOWN`` is used for a block whose discriminating key is not
+    one this library recognizes, so forward-compatibility is preserved when AWS adds new
+    block types.
+
+    The string values intentionally equal the corresponding
+    :class:`~bestehorn_llmmanager.bedrock.models.llm_manager_constants.ConverseAPIFields`
+    field constants, so the enum doubles as the field key when reading a block.
+    """
+
+    TEXT = ConverseAPIFields.TEXT
+    TOOL_USE = ConverseAPIFields.TOOL_USE
+    TOOL_RESULT = ConverseAPIFields.TOOL_RESULT
+    REASONING_CONTENT = ConverseAPIFields.REASONING_CONTENT
+    IMAGE = ConverseAPIFields.IMAGE
+    DOCUMENT = ConverseAPIFields.DOCUMENT
+    VIDEO = ConverseAPIFields.VIDEO
+    CITATIONS_CONTENT = ConverseAPIFields.CITATIONS_CONTENT
+    GUARD_CONTENT = ConverseAPIFields.GUARD_CONTENT
+    CACHE_POINT = ConverseAPIFields.CACHE_POINT
+    AUDIO = ConverseAPIFields.AUDIO
+    SEARCH_RESULT = ConverseAPIFields.SEARCH_RESULT
+    UNKNOWN = "unknown"
+
+    def __str__(self) -> str:
+        """Return the string value of the enum."""
+        return self.value
+
+    @classmethod
+    def from_block(cls, block: Any) -> "ResponseContentType":
+        """
+        Classify a single response content block by its discriminating union key.
+
+        The first recognized key present in the block determines its type. Recognized
+        keys are checked in a fixed, deterministic order so classification is stable.
+        ``block`` is typed ``Any`` because response content lists may legitimately
+        contain non-dict junk (defensively tolerated) — those classify as ``UNKNOWN``.
+
+        Args:
+            block: A single content-block dict from a Converse response message (or any
+                value; non-dict values classify as ``UNKNOWN``).
+
+        Returns:
+            The matching :class:`ResponseContentType`, or :attr:`ResponseContentType.UNKNOWN`
+            if the block is not a dict or contains no recognized discriminating key.
+        """
+        if not isinstance(block, dict):
+            return cls.UNKNOWN
+
+        for content_type in cls._ordered_known_types():
+            if content_type.value in block:
+                return content_type
+
+        return cls.UNKNOWN
+
+    @classmethod
+    def _ordered_known_types(cls) -> tuple["ResponseContentType", ...]:
+        """
+        Return the recognized (non-UNKNOWN) content types in deterministic check order.
+
+        Returns:
+            Tuple of every member except :attr:`UNKNOWN`, in declaration order.
+        """
+        return tuple(member for member in cls if member is not cls.UNKNOWN)
+
+
+def get_block_type(block: Optional[Dict[str, Any]]) -> ResponseContentType:
+    """
+    Convenience wrapper to classify a content block, tolerating ``None``.
+
+    Args:
+        block: A single content-block dict, or ``None``.
+
+    Returns:
+        The block's :class:`ResponseContentType`, or :attr:`ResponseContentType.UNKNOWN`
+        when ``block`` is ``None`` or not a dict.
+    """
+    if block is None:
+        return ResponseContentType.UNKNOWN
+    return ResponseContentType.from_block(block=block)

--- a/src/bestehorn_llmmanager/bedrock/models/llm_manager_constants.py
+++ b/src/bestehorn_llmmanager/bedrock/models/llm_manager_constants.py
@@ -38,6 +38,9 @@ class ConverseAPIFields:
     REASONING_CONTENT: Final[str] = "reasoningContent"
     TOOL_USE: Final[str] = "toolUse"
     TOOL_RESULT: Final[str] = "toolResult"
+    CITATIONS_CONTENT: Final[str] = "citationsContent"
+    AUDIO: Final[str] = "audio"
+    SEARCH_RESULT: Final[str] = "searchResult"
 
     # Image block fields
     FORMAT: Final[str] = "format"

--- a/test/bestehorn_llmmanager/bedrock/models/test_bedrock_response.py
+++ b/test/bestehorn_llmmanager/bedrock/models/test_bedrock_response.py
@@ -591,6 +591,147 @@ class TestBedrockResponse:
         assert "FAILED" in repr_str
 
 
+class TestBedrockResponseContentBlocks:
+    """Tests for the typed content-block iterator and accessors (issue #41)."""
+
+    def _mixed_modality_response(self):
+        """A response whose message mixes text, toolUse, reasoning, and image blocks."""
+        response_data = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"text": "First"},
+                        {"reasoningContent": {"reasoningText": {"text": "thinking"}}},
+                        {
+                            "toolUse": {
+                                "toolUseId": "tool-1",
+                                "name": "get_weather",
+                                "input": {"city": "Berlin"},
+                            }
+                        },
+                        {"image": {"format": "png", "source": {"bytes": b"\x89PNG"}}},
+                        {"text": "Second"},
+                    ],
+                }
+            }
+        }
+        return BedrockResponse(success=True, response_data=response_data)
+
+    def test_get_content_blocks_returns_all_in_order(self):
+        """get_content_blocks() returns every block in the original order."""
+        response = self._mixed_modality_response()
+        blocks = response.get_content_blocks()
+        assert blocks is not None
+        assert len(blocks) == 5
+        # Order preserved.
+        assert blocks[0] == {"text": "First"}
+        assert "reasoningContent" in blocks[1]
+        assert "toolUse" in blocks[2]
+        assert "image" in blocks[3]
+        assert blocks[4] == {"text": "Second"}
+
+    def test_get_content_blocks_is_a_copy(self):
+        """Mutating the returned list does not mutate the underlying response_data."""
+        response = self._mixed_modality_response()
+        blocks = response.get_content_blocks()
+        assert blocks is not None
+        original_len = len(response.response_data["output"]["message"]["content"])
+        blocks.append({"text": "injected"})
+        assert len(response.response_data["output"]["message"]["content"]) == original_len
+
+    def test_get_content_blocks_no_data(self):
+        """get_content_blocks() returns None when there is no usable response."""
+        assert BedrockResponse(success=True, response_data=None).get_content_blocks() is None
+        assert (
+            BedrockResponse(success=False, response_data={"output": {}}).get_content_blocks()
+            is None
+        )
+
+    def test_get_content_blocks_malformed(self):
+        """Malformed structures yield None rather than raising."""
+        assert (
+            BedrockResponse(success=True, response_data={"output": None}).get_content_blocks()
+            is None
+        )
+        assert (
+            BedrockResponse(
+                success=True, response_data={"output": {"message": {}}}
+            ).get_content_blocks()
+            is None
+        )
+
+    def test_get_content_blocks_by_type_enum(self):
+        """Filtering by ResponseContentType returns only matching blocks."""
+        from bestehorn_llmmanager.bedrock.models.content_block_types import (
+            ResponseContentType,
+        )
+
+        response = self._mixed_modality_response()
+        text_blocks = response.get_content_blocks_by_type(content_type=ResponseContentType.TEXT)
+        assert text_blocks == [{"text": "First"}, {"text": "Second"}]
+
+        tool_blocks = response.get_content_blocks_by_type(content_type=ResponseContentType.TOOL_USE)
+        assert len(tool_blocks) == 1
+        assert tool_blocks[0]["toolUse"]["name"] == "get_weather"
+
+    def test_get_content_blocks_by_type_string(self):
+        """Filtering accepts the raw string discriminating key too."""
+        response = self._mixed_modality_response()
+        image_blocks = response.get_content_blocks_by_type(content_type="image")
+        assert len(image_blocks) == 1
+        assert image_blocks[0]["image"]["format"] == "png"
+
+    def test_get_content_blocks_by_type_no_match(self):
+        """Filtering for an absent type returns an empty list."""
+        response = self._mixed_modality_response()
+        assert response.get_content_blocks_by_type(content_type="video") == []
+
+    def test_get_content_blocks_by_type_no_data(self):
+        """Filtering with no response data returns an empty list (not None)."""
+        response = BedrockResponse(success=True, response_data=None)
+        assert response.get_content_blocks_by_type(content_type="text") == []
+
+    def test_get_text_blocks(self):
+        """get_text_blocks() returns the ordered text strings only."""
+        response = self._mixed_modality_response()
+        assert response.get_text_blocks() == ["First", "Second"]
+
+    def test_get_text_blocks_no_data(self):
+        """get_text_blocks() returns an empty list when unavailable."""
+        assert BedrockResponse(success=True, response_data=None).get_text_blocks() == []
+
+    def test_get_image_blocks(self):
+        """get_image_blocks() returns the image payloads (value under 'image')."""
+        response = self._mixed_modality_response()
+        images = response.get_image_blocks()
+        assert len(images) == 1
+        assert images[0] == {"format": "png", "source": {"bytes": b"\x89PNG"}}
+
+    def test_get_image_blocks_none_present(self):
+        """get_image_blocks() returns an empty list for a text-only response."""
+        response_data = {"output": {"message": {"content": [{"text": "only text"}]}}}
+        response = BedrockResponse(success=True, response_data=response_data)
+        assert response.get_image_blocks() == []
+
+    def test_get_content_uses_iterator_and_is_unchanged(self):
+        """get_content() still joins text blocks, now via the shared iterator."""
+        response = self._mixed_modality_response()
+        # The two text blocks join with newline; non-text blocks are ignored.
+        assert response.get_content() == "First\nSecond"
+
+    def test_get_content_blocks_skips_non_dict_entries(self):
+        """Non-dict entries in the content list are tolerated and skipped by accessors."""
+        response_data = {"output": {"message": {"content": ["not_a_dict", {"text": "valid"}]}}}
+        response = BedrockResponse(success=True, response_data=response_data)
+        # The raw iterator returns the list as-is (including the junk entry)...
+        blocks = response.get_content_blocks()
+        assert blocks == ["not_a_dict", {"text": "valid"}]
+        # ...but the typed accessors classify only the well-formed block.
+        assert response.get_text_blocks() == ["valid"]
+        assert response.get_content() == "valid"
+
+
 class TestStreamingResponse:
     """Test StreamingResponse functionality."""
 

--- a/test/bestehorn_llmmanager/bedrock/models/test_content_block_types.py
+++ b/test/bestehorn_llmmanager/bedrock/models/test_content_block_types.py
@@ -1,0 +1,83 @@
+"""
+Tests for the ResponseContentType enum and block classifier (issue #41).
+"""
+
+import pytest
+
+from bestehorn_llmmanager.bedrock.models.content_block_types import (
+    ResponseContentType,
+    get_block_type,
+)
+
+
+class TestResponseContentTypeClassification:
+    """Classify each recognized ContentBlock union member."""
+
+    @pytest.mark.parametrize(
+        "block,expected",
+        [
+            ({"text": "hello"}, ResponseContentType.TEXT),
+            (
+                {"toolUse": {"toolUseId": "t1", "name": "calc", "input": {}}},
+                ResponseContentType.TOOL_USE,
+            ),
+            ({"toolResult": {"toolUseId": "t1", "content": []}}, ResponseContentType.TOOL_RESULT),
+            (
+                {"reasoningContent": {"reasoningText": {"text": "because"}}},
+                ResponseContentType.REASONING_CONTENT,
+            ),
+            ({"image": {"format": "png", "source": {"bytes": b"x"}}}, ResponseContentType.IMAGE),
+            (
+                {"document": {"format": "pdf", "name": "d", "source": {}}},
+                ResponseContentType.DOCUMENT,
+            ),
+            ({"video": {"format": "mp4", "source": {}}}, ResponseContentType.VIDEO),
+            (
+                {"citationsContent": {"content": [], "citations": []}},
+                ResponseContentType.CITATIONS_CONTENT,
+            ),
+            ({"guardContent": {"text": {"text": "g"}}}, ResponseContentType.GUARD_CONTENT),
+            ({"cachePoint": {"type": "default"}}, ResponseContentType.CACHE_POINT),
+            ({"audio": {"format": "wav", "source": {}}}, ResponseContentType.AUDIO),
+            ({"searchResult": {}}, ResponseContentType.SEARCH_RESULT),
+        ],
+    )
+    def test_from_block_recognizes_each_type(self, block, expected):
+        """Each known union member key classifies to its enum value."""
+        assert ResponseContentType.from_block(block=block) is expected
+
+    def test_from_block_unknown_key(self):
+        """A block with no recognized key is UNKNOWN (forward-compatible)."""
+        assert ResponseContentType.from_block(block={"brandNewBlock": {}}) is (
+            ResponseContentType.UNKNOWN
+        )
+
+    def test_from_block_non_dict(self):
+        """A non-dict block is UNKNOWN, not an error."""
+        assert ResponseContentType.from_block(block="not_a_dict") is ResponseContentType.UNKNOWN
+        assert ResponseContentType.from_block(block=[]) is ResponseContentType.UNKNOWN
+
+    def test_enum_value_equals_field_key(self):
+        """The enum value is exactly the JSON discriminating key."""
+        assert ResponseContentType.TEXT.value == "text"
+        assert ResponseContentType.TOOL_USE.value == "toolUse"
+        assert ResponseContentType.REASONING_CONTENT.value == "reasoningContent"
+        assert ResponseContentType.CITATIONS_CONTENT.value == "citationsContent"
+        assert str(ResponseContentType.IMAGE) == "image"
+
+    def test_ordered_known_types_excludes_unknown(self):
+        """The internal check order never includes UNKNOWN."""
+        ordered = ResponseContentType._ordered_known_types()
+        assert ResponseContentType.UNKNOWN not in ordered
+        assert ResponseContentType.TEXT in ordered
+        assert len(ordered) == len(list(ResponseContentType)) - 1
+
+
+class TestGetBlockTypeHelper:
+    """The get_block_type() convenience wrapper."""
+
+    def test_classifies_dict(self):
+        assert get_block_type(block={"text": "hi"}) is ResponseContentType.TEXT
+
+    def test_none_is_unknown(self):
+        assert get_block_type(block=None) is ResponseContentType.UNKNOWN

--- a/test/bestehorn_llmmanager/test_init.py
+++ b/test/bestehorn_llmmanager/test_init.py
@@ -30,6 +30,9 @@ class TestPackageInit:
         assert hasattr(bestehorn_llmmanager, "DocumentFormatEnum")
         assert hasattr(bestehorn_llmmanager, "VideoFormatEnum")
 
+        # Test response content-block typing
+        assert hasattr(bestehorn_llmmanager, "ResponseContentType")
+
     def test_version_handling_with_version_import_success(self):
         """Test version handling when _version import succeeds."""
         # This will use the actual _version.py file which should exist
@@ -95,6 +98,7 @@ class TestPackageInit:
             "DocumentFormatEnum",
             "VideoFormatEnum",
             "DetectionMethodEnum",
+            "ResponseContentType",
         ]
 
         assert hasattr(bestehorn_llmmanager, "__all__")


### PR DESCRIPTION
Closes #41.

## Problem

Response parsing was text-centric: `get_content()` joined only `text` blocks, and there was no typed way to iterate the other `ContentBlock` union members a model can return (`toolUse`, `reasoningContent`, `image`, `citationsContent`, ...). Non-text output was reachable only by hand-navigating the raw response dict. This is the response-side counterpart to the tool-use (#31) and reasoning (#32) gaps and is the general mechanism those build on.

## What this adds

- **`BedrockResponse.get_content_blocks()`** — the general accessor: returns the ordered list of typed content blocks (raw dicts, matching the project's dict + `ConverseAPIFields`-constant convention), or `None` when unavailable. Returns a shallow copy, so callers can't mutate `response_data`.
- **Type-specific accessors built on it**: `get_content_blocks_by_type(content_type)` (accepts the `ResponseContentType` enum or the raw key string), `get_text_blocks()`, and `get_image_blocks()` (the image-output extractor the issue asks for — returns the `ImageBlock` payloads).
- **`get_content()` refactored** to delegate to `get_text_blocks()` — behavior unchanged (the pre-existing `test_get_content_*` tests still pass).
- **`ResponseContentType(str, Enum)`** (new `content_block_types.py`) — values are the `ContentBlock` union discriminating keys; `from_block()` classifies any input, tolerating non-dict/unknown entries as `UNKNOWN` for forward-compatibility when AWS adds new block types. Added the missing `citationsContent`/`audio`/`searchResult` field constants. `ResponseContentType` is exported from the package.

## Design notes

- Raw-dict blocks (not new dataclasses) keep `get_content_blocks()` a true pass-through and stay consistent with how the codebase already models Converse content. Rationale + alternatives in the spec decision log (DL-001/002).
- The `ContentBlock` union members were taken from the AWS Bedrock Runtime `ContentBlock` API reference (consulted via the AWS docs MCP server).

## Proof

- New tests: `test_content_block_types.py` (18: each union member classified, unknown-key/non-dict → UNKNOWN, enum-value-equals-key) and `test_bedrock_response.py::TestBedrockResponseContentBlocks` (13: order preservation, copy-not-alias, None/malformed handling, by-type enum+string filtering, text/image extraction, non-dict-entry tolerance, `get_content()` unchanged). Plus `test_init.py` export assertions.
- Full unit suite: **2690 passed, 7 skipped, 0 failed**. New module `content_block_types.py` at **100%** coverage.
- `ruff format --check` ✓, `ruff check` ✓, `mypy --exclude="_version" src/` ✓.
- Independently re-verified by an adversarial pass (mutation testing confirmed every paired test fails when the behavior is removed/broken, then reverted): 16 claims tested, 0 refuted.

No breaking changes; `get_content()` semantics preserved.