### PR TITLE
Support the tool use (function calling) round-trip through the typed surface (#31)

### DIFF
--- a/docs/forLLMConsumption.md
+++ b/docs/forLLMConsumption.md
@@ -208,6 +208,71 @@ message = create_user_message()\
     .build()
 ```
 
+#### Tool Use (Function Calling) Round-Trip
+
+```python
+def add_tool_use(self, tool_use_id: str, name: str, input: Dict[str, Any]) -> 'ConverseMessageBuilder'
+def add_tool_result(
+    self,
+    tool_use_id: str,
+    content: Union[str, Dict[str, Any], List[Dict[str, Any]]],
+    status: Optional[Union[ToolResultStatusEnum, str]] = None,
+) -> 'ConverseMessageBuilder'
+```
+
+Build the two turns of a tool-use loop. `add_tool_use` replays the assistant turn in
+which the model requested a tool; `add_tool_result` carries the tool's output back as a
+user turn. `content` may be a `str` (→ a `text` result block), a `dict` (→ a `json`
+result block), or a pre-built list of `ToolResultContentBlock`s. `status` is
+`ToolResultStatusEnum.SUCCESS` / `.ERROR` (or the raw string), supported by Nova and
+Claude 3/4 models.
+
+Read a model's tool request out of a response with the typed accessors:
+
+```python
+def get_tool_uses(self) -> List[ToolUse]   # typed (tool_use_id, name, input) objects
+def has_tool_use(self) -> bool             # True if a toolUse block OR stopReason == tool_use
+```
+
+```python
+from bestehorn_llmmanager import (
+    create_user_message, create_assistant_message, ToolResultStatusEnum,
+)
+
+tool_config = {"tools": [{"toolSpec": {
+    "name": "get_weather",
+    "description": "Get the weather for a city.",
+    "inputSchema": {"json": {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    }},
+}}]}
+
+# Turn 1: the model asks for the tool.
+first = create_user_message().add_text("Weather in Paris?").build()
+resp = manager.converse(messages=[first], tool_config=tool_config)
+
+if resp.has_tool_use():
+    call = resp.get_tool_uses()[0]            # ToolUse(tool_use_id, name, input)
+    result = run_my_tool(call.name, call.input)   # your tool execution
+
+    # Turn 2: replay the assistant tool-call turn + the tool result, then continue.
+    assistant_turn = create_assistant_message()\
+        .add_tool_use(tool_use_id=call.tool_use_id, name=call.name, input=call.input)\
+        .build()
+    result_turn = create_user_message()\
+        .add_tool_result(
+            tool_use_id=call.tool_use_id, content=result,
+            status=ToolResultStatusEnum.SUCCESS,
+        )\
+        .build()
+    final = manager.converse(
+        messages=[first, assistant_turn, result_turn], tool_config=tool_config
+    )
+    print(final.get_content())
+```
+
 #### Building Messages
 
 ```python
@@ -710,6 +775,10 @@ tool_blocks = response.get_content_blocks_by_type(       # List[dict]: blocks of
 )
 text_parts = response.get_text_blocks()                  # List[str]: the text strings, in order
 images = response.get_image_blocks()                     # List[dict]: ImageBlock payloads ({"format","source"})
+
+# Tool use (function calling) — see the MessageBuilder tool-use round-trip section
+tool_uses = response.get_tool_uses()                     # List[ToolUse]: typed (tool_use_id, name, input)
+asked_for_tool = response.has_tool_use()                 # bool: toolUse block present OR stopReason == tool_use
 
 # Token usage accessor methods (recommended)
 input_tokens = response.get_input_tokens()               # Int: Input tokens used

--- a/src/bestehorn_llmmanager/__init__.py
+++ b/src/bestehorn_llmmanager/__init__.py
@@ -47,6 +47,9 @@ from .bedrock.models.llm_manager_structures import Boto3Config
 
 # Model-specific configuration and tracking
 from .bedrock.models.model_specific_structures import ModelSpecificConfig
+
+# Tool use (function calling) typed request object
+from .bedrock.models.tool_use import ToolUse
 from .bedrock.tracking.parameter_compatibility_tracker import ParameterCompatibilityTracker
 
 # Package metadata
@@ -64,6 +67,7 @@ from .message_builder_enums import (
     DocumentFormatEnum,
     ImageFormatEnum,
     RolesEnum,
+    ToolResultStatusEnum,
     VideoFormatEnum,
 )
 from .parallel_llm_manager import ParallelLLMManager
@@ -102,8 +106,11 @@ __all__ = [
     "DocumentFormatEnum",
     "VideoFormatEnum",
     "DetectionMethodEnum",
+    "ToolResultStatusEnum",
     # Response content-block typing
     "ResponseContentType",
+    # Tool use (function calling)
+    "ToolUse",
     # Region utilities
     "BedrockRegionDiscovery",
     "get_all_regions",

--- a/src/bestehorn_llmmanager/bedrock/models/bedrock_response.py
+++ b/src/bestehorn_llmmanager/bedrock/models/bedrock_response.py
@@ -12,6 +12,7 @@ from .content_block_types import ResponseContentType
 from .llm_manager_constants import ConverseAPIFields
 from .llm_manager_structures import RequestAttempt, ValidationAttempt
 from .stop_reason import StopReasonCategory, StopReasonClassifier
+from .tool_use import ToolUse
 
 
 @dataclass
@@ -159,6 +160,38 @@ class BedrockResponse:
             block[ConverseAPIFields.IMAGE]
             for block in self.get_content_blocks_by_type(content_type=ResponseContentType.IMAGE)
         ]
+
+    def get_tool_uses(self) -> List[ToolUse]:
+        """
+        Get the tool-use (function-call) requests from the response, in order.
+
+        Parses every ``toolUse`` content block into a typed :class:`ToolUse`
+        (id, name, parsed input), so a tool-use turn is reachable without touching the
+        raw response dict. Built on :meth:`get_content_blocks_by_type`.
+
+        Returns:
+            The ordered list of :class:`ToolUse`; an empty list if the response contains
+            no tool-use blocks.
+        """
+        return [
+            ToolUse.from_tool_use_block(tool_use_block=block[ConverseAPIFields.TOOL_USE])
+            for block in self.get_content_blocks_by_type(content_type=ResponseContentType.TOOL_USE)
+        ]
+
+    def has_tool_use(self) -> bool:
+        """
+        Check whether the model requested a tool call.
+
+        True if the response contains a ``toolUse`` content block OR its stop reason is
+        ``tool_use`` (the model may signal a tool turn via the stop reason even before
+        the blocks are inspected).
+
+        Returns:
+            True if a tool call was requested, False otherwise.
+        """
+        if self.get_tool_uses():
+            return True
+        return self.get_stop_reason() == ConverseAPIFields.STOP_REASON_TOOL_USE
 
     def get_content(self) -> Optional[str]:
         """

--- a/src/bestehorn_llmmanager/bedrock/models/llm_manager_constants.py
+++ b/src/bestehorn_llmmanager/bedrock/models/llm_manager_constants.py
@@ -53,6 +53,16 @@ class ConverseAPIFields:
     # Document block fields
     NAME: Final[str] = "name"
 
+    # Tool use / tool result block fields
+    TOOL_USE_ID: Final[str] = "toolUseId"
+    TOOL_NAME: Final[str] = "name"
+    TOOL_INPUT: Final[str] = "input"
+    TOOL_RESULT_CONTENT: Final[str] = "content"
+    TOOL_RESULT_STATUS: Final[str] = "status"
+    TOOL_RESULT_JSON: Final[str] = "json"
+    TOOL_RESULT_STATUS_SUCCESS: Final[str] = "success"
+    TOOL_RESULT_STATUS_ERROR: Final[str] = "error"
+
     # Inference configuration fields
     MAX_TOKENS: Final[str] = "maxTokens"
     STOP_SEQUENCES: Final[str] = "stopSequences"

--- a/src/bestehorn_llmmanager/bedrock/models/tool_use.py
+++ b/src/bestehorn_llmmanager/bedrock/models/tool_use.py
@@ -1,0 +1,50 @@
+"""
+Typed tool-use (function-calling) request parsed from a Bedrock Converse response.
+
+Defines :class:`ToolUse`, the typed view of a ``toolUse`` content block a model emits
+when it wants a tool run, so callers can read the tool id/name/input without
+hand-navigating the raw response dictionary.
+
+Reference: AWS Bedrock Runtime ``ToolUseBlock``
+https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolUseBlock.html
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from .llm_manager_constants import ConverseAPIFields
+
+
+@dataclass(frozen=True)
+class ToolUse:
+    """
+    A single tool-use (function-call) request emitted by the model.
+
+    Attributes:
+        tool_use_id: The ID for the tool request (echo it back on the matching
+            ``toolResult``).
+        name: The name of the tool the model wants to use.
+        input: The parsed input arguments to pass to the tool (a JSON object).
+    """
+
+    tool_use_id: str
+    name: str
+    input: Dict[str, Any]
+
+    @classmethod
+    def from_tool_use_block(cls, tool_use_block: Dict[str, Any]) -> "ToolUse":
+        """
+        Build a :class:`ToolUse` from the payload under a block's ``toolUse`` key.
+
+        Args:
+            tool_use_block: The ``ToolUseBlock`` payload — the value under the
+                ``toolUse`` key of a content block (``{"toolUseId", "name", "input"}``).
+
+        Returns:
+            The typed :class:`ToolUse`. Missing ``input`` defaults to an empty dict.
+        """
+        return cls(
+            tool_use_id=tool_use_block.get(ConverseAPIFields.TOOL_USE_ID, ""),
+            name=tool_use_block.get(ConverseAPIFields.TOOL_NAME, ""),
+            input=tool_use_block.get(ConverseAPIFields.TOOL_INPUT, {}) or {},
+        )

--- a/src/bestehorn_llmmanager/message_builder.py
+++ b/src/bestehorn_llmmanager/message_builder.py
@@ -7,7 +7,7 @@ validation, and multi-modal support.
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from .bedrock.exceptions.llm_manager_exceptions import RequestValidationError
 from .bedrock.models.cache_structures import CacheConfig
@@ -18,7 +18,13 @@ from .message_builder_constants import (
     MessageBuilderLogMessages,
     SupportedFormats,
 )
-from .message_builder_enums import DocumentFormatEnum, ImageFormatEnum, RolesEnum, VideoFormatEnum
+from .message_builder_enums import (
+    DocumentFormatEnum,
+    ImageFormatEnum,
+    RolesEnum,
+    ToolResultStatusEnum,
+    VideoFormatEnum,
+)
 from .util.file_type_detector import FileTypeDetector
 
 
@@ -593,6 +599,184 @@ class ConverseMessageBuilder:
         )
 
         return self
+
+    def add_tool_use(
+        self, tool_use_id: str, name: str, input: Dict[str, Any]
+    ) -> "ConverseMessageBuilder":
+        """
+        Add a ``toolUse`` content block (an assistant tool-call request).
+
+        Use this to replay an assistant turn in which the model requested a tool, so the
+        conversation can continue after you run the tool and return its result via
+        :meth:`add_tool_result`.
+
+        Args:
+            tool_use_id: The tool request ID (echoed back on the matching tool result).
+            name: The name of the tool the model wants to use.
+            input: The input arguments to pass to the tool (a JSON object).
+
+        Returns:
+            Self for method chaining.
+
+        Raises:
+            RequestValidationError: If ``tool_use_id`` or ``name`` is empty, or ``input``
+                is not a dict.
+        """
+        if not tool_use_id or not tool_use_id.strip():
+            raise RequestValidationError(
+                MessageBuilderErrorMessages.EMPTY_CONTENT.format(content_type="tool_use_id")
+            )
+        if not name or not name.strip():
+            raise RequestValidationError(
+                MessageBuilderErrorMessages.EMPTY_CONTENT.format(content_type="tool name")
+            )
+        if not isinstance(input, dict):
+            raise RequestValidationError(
+                MessageBuilderErrorMessages.INVALID_CONTENT_TYPE.format(
+                    content_type=f"tool input (expected a JSON object, got {type(input).__name__})"
+                )
+            )
+
+        self._validate_content_block_limit()
+
+        tool_use_block = {
+            ConverseAPIFields.TOOL_USE: {
+                ConverseAPIFields.TOOL_USE_ID: tool_use_id,
+                ConverseAPIFields.TOOL_NAME: name,
+                ConverseAPIFields.TOOL_INPUT: input,
+            }
+        }
+
+        self._content_blocks.append(tool_use_block)
+        self._cacheable_blocks.append(False)
+
+        self._logger.debug(
+            MessageBuilderLogMessages.CONTENT_BLOCK_ADDED.format(
+                content_type=f"tool_use ({name})", size=len(str(input))
+            )
+        )
+
+        return self
+
+    def add_tool_result(
+        self,
+        tool_use_id: str,
+        content: Union[str, Dict[str, Any], List[Dict[str, Any]]],
+        status: Optional[Union[ToolResultStatusEnum, str]] = None,
+    ) -> "ConverseMessageBuilder":
+        """
+        Add a ``toolResult`` content block (a user turn carrying a tool's result).
+
+        Args:
+            tool_use_id: The ID of the tool request this result is for (must match the
+                ``toolUse`` it answers).
+            content: The tool result. A ``str`` becomes a single ``text``
+                ToolResultContentBlock; a ``dict`` becomes a single ``json`` block; a
+                ``list`` is treated as pre-built ToolResultContentBlocks and passed
+                through verbatim.
+            status: Optional result status — a :class:`ToolResultStatusEnum` or the raw
+                string ``"success"``/``"error"`` (supported by Nova and Claude 3/4).
+
+        Returns:
+            Self for method chaining.
+
+        Raises:
+            RequestValidationError: If ``tool_use_id`` is empty, ``content`` is an
+                unsupported type, or ``status`` is not a valid value.
+        """
+        if not tool_use_id or not tool_use_id.strip():
+            raise RequestValidationError(
+                MessageBuilderErrorMessages.EMPTY_CONTENT.format(content_type="tool_use_id")
+            )
+
+        result_content = self._build_tool_result_content(content=content)
+
+        self._validate_content_block_limit()
+
+        # Typed as Dict[str, Any] so the optional status string can be added below without
+        # mypy narrowing the value type from the content list.
+        tool_result: Dict[str, Any] = {
+            ConverseAPIFields.TOOL_USE_ID: tool_use_id,
+            ConverseAPIFields.TOOL_RESULT_CONTENT: result_content,
+        }
+
+        if status is not None:
+            tool_result[ConverseAPIFields.TOOL_RESULT_STATUS] = self._normalize_tool_status(
+                status=status
+            )
+
+        self._content_blocks.append({ConverseAPIFields.TOOL_RESULT: tool_result})
+        self._cacheable_blocks.append(False)
+
+        self._logger.debug(
+            MessageBuilderLogMessages.CONTENT_BLOCK_ADDED.format(
+                content_type="tool_result", size=len(str(result_content))
+            )
+        )
+
+        return self
+
+    def _build_tool_result_content(
+        self, content: Union[str, Dict[str, Any], List[Dict[str, Any]]]
+    ) -> List[Dict[str, Any]]:
+        """
+        Normalize a tool-result ``content`` argument into a ToolResultContentBlock list.
+
+        Args:
+            content: A ``str`` (-> text block), a ``dict`` (-> json block), or a ``list``
+                of pre-built ToolResultContentBlocks (passed through).
+
+        Returns:
+            The list of ToolResultContentBlocks.
+
+        Raises:
+            RequestValidationError: If ``content`` is empty or an unsupported type.
+        """
+        if isinstance(content, str):
+            if not content.strip():
+                raise RequestValidationError(
+                    MessageBuilderErrorMessages.EMPTY_CONTENT.format(content_type="tool_result")
+                )
+            return [{ConverseAPIFields.TEXT: content}]
+        if isinstance(content, list):
+            if not content:
+                raise RequestValidationError(
+                    MessageBuilderErrorMessages.EMPTY_CONTENT.format(content_type="tool_result")
+                )
+            return content
+        if isinstance(content, dict):
+            return [{ConverseAPIFields.TOOL_RESULT_JSON: content}]
+        raise RequestValidationError(
+            MessageBuilderErrorMessages.INVALID_CONTENT_TYPE.format(
+                content_type=(
+                    f"tool_result content (expected str, dict, or list, "
+                    f"got {type(content).__name__})"
+                )
+            )
+        )
+
+    def _normalize_tool_status(self, status: Union[ToolResultStatusEnum, str]) -> str:
+        """
+        Validate a tool-result status and return its string value.
+
+        Args:
+            status: A :class:`ToolResultStatusEnum` or the raw string value.
+
+        Returns:
+            The validated status string (``"success"`` or ``"error"``).
+
+        Raises:
+            RequestValidationError: If the status is not a valid value.
+        """
+        if isinstance(status, ToolResultStatusEnum):
+            return status.value
+        try:
+            return ToolResultStatusEnum(status).value
+        except ValueError as exc:
+            valid = ", ".join(member.value for member in ToolResultStatusEnum)
+            raise RequestValidationError(
+                f"Invalid tool_result status '{status}'. Valid values are: {valid}"
+            ) from exc
 
     def build(self) -> Dict[str, Any]:
         """

--- a/src/bestehorn_llmmanager/message_builder_constants.py
+++ b/src/bestehorn_llmmanager/message_builder_constants.py
@@ -78,6 +78,7 @@ class MessageBuilderErrorMessages:
     # Configuration errors
     INVALID_ROLE: Final[str] = "Invalid role specified: {role}. Must be one of: {valid_roles}"
     EMPTY_CONTENT: Final[str] = "Content cannot be empty for {content_type}"
+    INVALID_CONTENT_TYPE: Final[str] = "Invalid content type: {content_type}"
     INVALID_FORMAT: Final[str] = (
         "Invalid {content_type} format: {format}. Supported formats: {supported_formats}"
     )

--- a/src/bestehorn_llmmanager/message_builder_enums.py
+++ b/src/bestehorn_llmmanager/message_builder_enums.py
@@ -85,3 +85,20 @@ class DetectionMethodEnum(str, Enum):
     CONTENT = "content"
     COMBINED = "combined"
     MANUAL = "manual"
+
+
+class ToolResultStatusEnum(str, Enum):
+    """
+    Enumeration of valid tool-result statuses for the Converse API.
+
+    Set on a ``toolResult`` block to tell the model whether the tool call succeeded or
+    failed. Values map directly to the Converse ``ToolResultBlock.status`` valid values
+    (``success`` | ``error``). Supported by Amazon Nova and Anthropic Claude 3/4 models.
+    """
+
+    SUCCESS = ConverseAPIFields.TOOL_RESULT_STATUS_SUCCESS
+    ERROR = ConverseAPIFields.TOOL_RESULT_STATUS_ERROR
+
+    def __str__(self) -> str:
+        """Return the string value of the enum."""
+        return self.value

--- a/test/bestehorn_llmmanager/bedrock/models/test_bedrock_response.py
+++ b/test/bestehorn_llmmanager/bedrock/models/test_bedrock_response.py
@@ -591,6 +591,98 @@ class TestBedrockResponse:
         assert "FAILED" in repr_str
 
 
+class TestBedrockResponseToolUse:
+    """Tests for the tool-use response accessors (issue #31)."""
+
+    def _tool_use_response(self):
+        """A response whose assistant message contains a toolUse block + tool_use stop."""
+        response_data = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"text": "Let me look that up."},
+                        {
+                            "toolUse": {
+                                "toolUseId": "tool-42",
+                                "name": "get_weather",
+                                "input": {"city": "Paris"},
+                            }
+                        },
+                    ],
+                }
+            },
+            "stopReason": "tool_use",
+        }
+        return BedrockResponse(success=True, response_data=response_data)
+
+    def test_get_tool_uses_returns_typed_objects(self):
+        """get_tool_uses() returns typed ToolUse objects parsed from the response."""
+        from bestehorn_llmmanager.bedrock.models.tool_use import ToolUse
+
+        response = self._tool_use_response()
+        tool_uses = response.get_tool_uses()
+        assert len(tool_uses) == 1
+        assert isinstance(tool_uses[0], ToolUse)
+        assert tool_uses[0].tool_use_id == "tool-42"
+        assert tool_uses[0].name == "get_weather"
+        assert tool_uses[0].input == {"city": "Paris"}
+
+    def test_get_tool_uses_multiple(self):
+        """Multiple toolUse blocks all parse, in order."""
+        response_data = {
+            "output": {
+                "message": {
+                    "content": [
+                        {"toolUse": {"toolUseId": "a", "name": "one", "input": {}}},
+                        {"toolUse": {"toolUseId": "b", "name": "two", "input": {"x": 1}}},
+                    ]
+                }
+            },
+            "stopReason": "tool_use",
+        }
+        response = BedrockResponse(success=True, response_data=response_data)
+        tool_uses = response.get_tool_uses()
+        assert [t.tool_use_id for t in tool_uses] == ["a", "b"]
+        assert tool_uses[1].input == {"x": 1}
+
+    def test_get_tool_uses_none_present(self):
+        """A text-only response yields no tool uses."""
+        response_data = {"output": {"message": {"content": [{"text": "hi"}]}}}
+        response = BedrockResponse(success=True, response_data=response_data)
+        assert response.get_tool_uses() == []
+
+    def test_get_tool_uses_no_data(self):
+        """No response data yields an empty list."""
+        assert BedrockResponse(success=True, response_data=None).get_tool_uses() == []
+
+    def test_has_tool_use_true_when_block_present(self):
+        """has_tool_use() is True when a toolUse block exists."""
+        assert self._tool_use_response().has_tool_use() is True
+
+    def test_has_tool_use_true_on_stop_reason_only(self):
+        """has_tool_use() is True when stopReason is tool_use even before blocks parse."""
+        response_data = {
+            "output": {"message": {"content": [{"text": "thinking"}]}},
+            "stopReason": "tool_use",
+        }
+        response = BedrockResponse(success=True, response_data=response_data)
+        assert response.has_tool_use() is True
+
+    def test_has_tool_use_false_for_plain_text(self):
+        """has_tool_use() is False for a plain end_turn text response."""
+        response_data = {
+            "output": {"message": {"content": [{"text": "done"}]}},
+            "stopReason": "end_turn",
+        }
+        response = BedrockResponse(success=True, response_data=response_data)
+        assert response.has_tool_use() is False
+
+    def test_has_tool_use_false_no_data(self):
+        """has_tool_use() is False when there is no usable response."""
+        assert BedrockResponse(success=False, response_data=None).has_tool_use() is False
+
+
 class TestBedrockResponseContentBlocks:
     """Tests for the typed content-block iterator and accessors (issue #41)."""
 

--- a/test/bestehorn_llmmanager/bedrock/models/test_tool_use.py
+++ b/test/bestehorn_llmmanager/bedrock/models/test_tool_use.py
@@ -1,0 +1,35 @@
+"""
+Tests for the ToolUse typed tool-call object (issue #31).
+"""
+
+from bestehorn_llmmanager.bedrock.models.tool_use import ToolUse
+
+
+class TestToolUseFromBlock:
+    """Build ToolUse from a raw toolUse block payload."""
+
+    def test_from_tool_use_block_full(self):
+        payload = {"toolUseId": "t-1", "name": "get_weather", "input": {"city": "Berlin"}}
+        tool_use = ToolUse.from_tool_use_block(tool_use_block=payload)
+        assert tool_use.tool_use_id == "t-1"
+        assert tool_use.name == "get_weather"
+        assert tool_use.input == {"city": "Berlin"}
+
+    def test_from_tool_use_block_missing_input_defaults_empty(self):
+        payload = {"toolUseId": "t-2", "name": "ping"}
+        tool_use = ToolUse.from_tool_use_block(tool_use_block=payload)
+        assert tool_use.input == {}
+
+    def test_from_tool_use_block_none_input_defaults_empty(self):
+        payload = {"toolUseId": "t-3", "name": "ping", "input": None}
+        tool_use = ToolUse.from_tool_use_block(tool_use_block=payload)
+        assert tool_use.input == {}
+
+    def test_is_frozen(self):
+        tool_use = ToolUse(tool_use_id="t-1", name="n", input={})
+        import dataclasses
+
+        import pytest
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            tool_use.name = "other"  # type: ignore[misc]

--- a/test/bestehorn_llmmanager/test_init.py
+++ b/test/bestehorn_llmmanager/test_init.py
@@ -33,6 +33,10 @@ class TestPackageInit:
         # Test response content-block typing
         assert hasattr(bestehorn_llmmanager, "ResponseContentType")
 
+        # Test tool-use round-trip types
+        assert hasattr(bestehorn_llmmanager, "ToolResultStatusEnum")
+        assert hasattr(bestehorn_llmmanager, "ToolUse")
+
     def test_version_handling_with_version_import_success(self):
         """Test version handling when _version import succeeds."""
         # This will use the actual _version.py file which should exist
@@ -99,6 +103,8 @@ class TestPackageInit:
             "VideoFormatEnum",
             "DetectionMethodEnum",
             "ResponseContentType",
+            "ToolResultStatusEnum",
+            "ToolUse",
         ]
 
         assert hasattr(bestehorn_llmmanager, "__all__")

--- a/test/bestehorn_llmmanager/test_message_builder.py
+++ b/test/bestehorn_llmmanager/test_message_builder.py
@@ -973,3 +973,174 @@ class TestComplexScenarios:
 
         with pytest.raises(RequestValidationError, match="Unsupported format"):
             builder.add_image_bytes(bytes=image_data, filename="test.unk")
+
+
+class TestAddToolUseMethod:
+    """Test cases for MessageBuilder.add_tool_use (issue #31)."""
+
+    def test_add_tool_use_builds_block(self):
+        """add_tool_use produces a toolUse content block with id/name/input."""
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.ASSISTANT)
+            .add_tool_use(tool_use_id="t-1", name="get_weather", input={"city": "Berlin"})
+            .build()
+        )
+        blocks = message[ConverseAPIFields.CONTENT]
+        assert len(blocks) == 1
+        tool_use = blocks[0][ConverseAPIFields.TOOL_USE]
+        assert tool_use[ConverseAPIFields.TOOL_USE_ID] == "t-1"
+        assert tool_use[ConverseAPIFields.TOOL_NAME] == "get_weather"
+        assert tool_use[ConverseAPIFields.TOOL_INPUT] == {"city": "Berlin"}
+
+    def test_add_tool_use_returns_self_for_chaining(self):
+        """add_tool_use returns the builder for fluent chaining."""
+        builder = ConverseMessageBuilder(role=RolesEnum.ASSISTANT)
+        result = builder.add_tool_use(tool_use_id="t-1", name="calc", input={})
+        assert result is builder
+
+    def test_add_tool_use_empty_id_rejected(self):
+        """An empty tool_use_id is rejected."""
+        with pytest.raises(RequestValidationError):
+            ConverseMessageBuilder(role=RolesEnum.ASSISTANT).add_tool_use(
+                tool_use_id="", name="calc", input={}
+            )
+
+    def test_add_tool_use_empty_name_rejected(self):
+        """An empty tool name is rejected."""
+        with pytest.raises(RequestValidationError):
+            ConverseMessageBuilder(role=RolesEnum.ASSISTANT).add_tool_use(
+                tool_use_id="t-1", name="", input={}
+            )
+
+    def test_add_tool_use_non_dict_input_rejected(self):
+        """A non-dict input is rejected (toolUse.input must be a JSON object)."""
+        with pytest.raises(RequestValidationError):
+            ConverseMessageBuilder(role=RolesEnum.ASSISTANT).add_tool_use(
+                tool_use_id="t-1",
+                name="calc",
+                input="not-a-dict",  # type: ignore[arg-type]
+            )
+
+
+class TestAddToolResultMethod:
+    """Test cases for MessageBuilder.add_tool_result (issue #31)."""
+
+    def test_add_tool_result_text(self):
+        """A string result becomes a single text ToolResultContentBlock."""
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.USER)
+            .add_tool_result(tool_use_id="t-1", content="22 degrees")
+            .build()
+        )
+        tool_result = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.TOOL_RESULT]
+        assert tool_result[ConverseAPIFields.TOOL_USE_ID] == "t-1"
+        assert tool_result[ConverseAPIFields.TOOL_RESULT_CONTENT] == [
+            {ConverseAPIFields.TEXT: "22 degrees"}
+        ]
+        # status omitted when not provided
+        assert ConverseAPIFields.TOOL_RESULT_STATUS not in tool_result
+
+    def test_add_tool_result_json(self):
+        """A dict result becomes a single json ToolResultContentBlock."""
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.USER)
+            .add_tool_result(tool_use_id="t-1", content={"temp_c": 22})
+            .build()
+        )
+        tool_result = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.TOOL_RESULT]
+        assert tool_result[ConverseAPIFields.TOOL_RESULT_CONTENT] == [
+            {ConverseAPIFields.TOOL_RESULT_JSON: {"temp_c": 22}}
+        ]
+
+    def test_add_tool_result_status_enum(self):
+        """The status accepts a ToolResultStatusEnum and serializes its value."""
+        from bestehorn_llmmanager.message_builder_enums import ToolResultStatusEnum
+
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.USER)
+            .add_tool_result(tool_use_id="t-1", content="boom", status=ToolResultStatusEnum.ERROR)
+            .build()
+        )
+        tool_result = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.TOOL_RESULT]
+        assert tool_result[ConverseAPIFields.TOOL_RESULT_STATUS] == "error"
+
+    def test_add_tool_result_status_string(self):
+        """The status accepts the raw string 'success'/'error'."""
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.USER)
+            .add_tool_result(tool_use_id="t-1", content="ok", status="success")
+            .build()
+        )
+        tool_result = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.TOOL_RESULT]
+        assert tool_result[ConverseAPIFields.TOOL_RESULT_STATUS] == "success"
+
+    def test_add_tool_result_invalid_status_rejected(self):
+        """An out-of-range status string is rejected."""
+        with pytest.raises(RequestValidationError):
+            ConverseMessageBuilder(role=RolesEnum.USER).add_tool_result(
+                tool_use_id="t-1", content="x", status="maybe"
+            )
+
+    def test_add_tool_result_prebuilt_content_list(self):
+        """A pre-built list of ToolResultContentBlocks is passed through verbatim."""
+        prebuilt = [
+            {ConverseAPIFields.TEXT: "line 1"},
+            {ConverseAPIFields.TOOL_RESULT_JSON: {"k": "v"}},
+        ]
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.USER)
+            .add_tool_result(tool_use_id="t-1", content=prebuilt)
+            .build()
+        )
+        tool_result = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.TOOL_RESULT]
+        assert tool_result[ConverseAPIFields.TOOL_RESULT_CONTENT] == prebuilt
+
+    def test_add_tool_result_empty_id_rejected(self):
+        """An empty tool_use_id is rejected."""
+        with pytest.raises(RequestValidationError):
+            ConverseMessageBuilder(role=RolesEnum.USER).add_tool_result(tool_use_id="", content="x")
+
+    def test_add_tool_result_returns_self(self):
+        """add_tool_result returns the builder for chaining."""
+        builder = ConverseMessageBuilder(role=RolesEnum.USER)
+        assert builder.add_tool_result(tool_use_id="t-1", content="x") is builder
+
+    def test_add_tool_result_empty_string_content_rejected(self):
+        """An empty/whitespace string result is rejected."""
+        with pytest.raises(RequestValidationError):
+            ConverseMessageBuilder(role=RolesEnum.USER).add_tool_result(
+                tool_use_id="t-1", content="   "
+            )
+
+    def test_add_tool_result_empty_list_content_rejected(self):
+        """An empty pre-built content list is rejected."""
+        with pytest.raises(RequestValidationError):
+            ConverseMessageBuilder(role=RolesEnum.USER).add_tool_result(
+                tool_use_id="t-1", content=[]
+            )
+
+    def test_add_tool_result_unsupported_content_type_rejected(self):
+        """A content type that is not str/dict/list is rejected."""
+        with pytest.raises(RequestValidationError):
+            ConverseMessageBuilder(role=RolesEnum.USER).add_tool_result(
+                tool_use_id="t-1",
+                content=42,  # type: ignore[arg-type]
+            )
+
+    def test_tool_round_trip_chaining(self):
+        """An assistant toolUse turn and a user toolResult turn build correctly."""
+        assistant = (
+            ConverseMessageBuilder(role=RolesEnum.ASSISTANT)
+            .add_text("Let me check the weather.")
+            .add_tool_use(tool_use_id="t-9", name="get_weather", input={"city": "Paris"})
+            .build()
+        )
+        user = (
+            ConverseMessageBuilder(role=RolesEnum.USER)
+            .add_tool_result(tool_use_id="t-9", content={"temp_c": 18}, status="success")
+            .build()
+        )
+        assert assistant[ConverseAPIFields.ROLE] == "assistant"
+        assert ConverseAPIFields.TOOL_USE in assistant[ConverseAPIFields.CONTENT][1]
+        assert user[ConverseAPIFields.ROLE] == "user"
+        assert ConverseAPIFields.TOOL_RESULT in user[ConverseAPIFields.CONTENT][0]

--- a/test/bestehorn_llmmanager/test_tool_use_roundtrip.py
+++ b/test/bestehorn_llmmanager/test_tool_use_roundtrip.py
@@ -1,0 +1,160 @@
+"""
+End-to-end (mocked) tool-use round-trip test for issue #31.
+
+Exercises the full public surface — MessageBuilder.add_tool_use / add_tool_result and
+BedrockResponse.get_tool_uses / has_tool_use — across a two-turn tool loop driven through
+LLMManager.converse with a mocked Bedrock client (no AWS). The first model turn requests
+a tool; the caller runs the tool, appends a toolResult, and the second model turn returns
+the final answer.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from bestehorn_llmmanager import (
+    LLMManager,
+    RolesEnum,
+    ToolResultStatusEnum,
+    ToolUse,
+    create_assistant_message,
+    create_user_message,
+)
+from bestehorn_llmmanager.bedrock.models.llm_manager_constants import ConverseAPIFields
+
+
+@pytest.fixture
+def mock_bedrock_catalog():
+    """A catalog that resolves the test model with direct access."""
+    catalog = Mock()
+    catalog.get_model_info.return_value = Mock(
+        model_id="test-model-id",
+        has_direct_access=True,
+        has_regional_cris=False,
+        has_global_cris=False,
+        regional_cris_profile_id=None,
+        global_cris_profile_id=None,
+    )
+    catalog.is_model_available.return_value = True
+    return catalog
+
+
+@pytest.fixture
+def manager(mock_bedrock_catalog):
+    """A basic LLMManager wired to the mocked catalog."""
+    with patch(
+        "bestehorn_llmmanager.llm_manager.BedrockModelCatalog",
+        return_value=mock_bedrock_catalog,
+    ):
+        return LLMManager(models=["Claude Haiku 4 5 20251001"], regions=["us-east-1"])
+
+
+class TestToolUseRoundTripMocked:
+    """A full request -> toolUse -> toolResult -> final-answer loop, mocked."""
+
+    def test_tool_loop(self, manager):
+        tool_use_turn = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"text": "Let me check the weather."},
+                        {
+                            "toolUse": {
+                                "toolUseId": "tool-77",
+                                "name": "get_weather",
+                                "input": {"city": "Paris"},
+                            }
+                        },
+                    ],
+                }
+            },
+            "stopReason": "tool_use",
+        }
+        final_turn = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [{"text": "It is 18 degrees in Paris."}],
+                }
+            },
+            "stopReason": "end_turn",
+        }
+
+        mock_client = Mock()
+        mock_client.converse.side_effect = [tool_use_turn, final_turn]
+
+        tool_config = {
+            "tools": [
+                {
+                    "toolSpec": {
+                        "name": "get_weather",
+                        "description": "Get the weather for a city.",
+                        "inputSchema": {
+                            "json": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                                "required": ["city"],
+                            }
+                        },
+                    }
+                }
+            ]
+        }
+
+        with patch.object(manager._auth_manager, "get_bedrock_client", return_value=mock_client):
+            # Turn 1: the user asks; the model requests the tool.
+            first_message = create_user_message().add_text("What is the weather in Paris?").build()
+            first = manager.converse(messages=[first_message], tool_config=tool_config)
+
+            assert first.success is True
+            assert first.has_tool_use() is True
+            tool_uses = first.get_tool_uses()
+            assert len(tool_uses) == 1
+            tool_use = tool_uses[0]
+            assert isinstance(tool_use, ToolUse)
+            assert tool_use.name == "get_weather"
+            assert tool_use.input == {"city": "Paris"}
+
+            # The caller "runs" the tool, then replays the assistant turn and the result.
+            assistant_turn = (
+                create_assistant_message()
+                .add_text("Let me check the weather.")
+                .add_tool_use(
+                    tool_use_id=tool_use.tool_use_id,
+                    name=tool_use.name,
+                    input=tool_use.input,
+                )
+                .build()
+            )
+            tool_result_turn = (
+                create_user_message()
+                .add_tool_result(
+                    tool_use_id=tool_use.tool_use_id,
+                    content={"temp_c": 18},
+                    status=ToolResultStatusEnum.SUCCESS,
+                )
+                .build()
+            )
+
+            # The replayed turns are well-formed.
+            assert assistant_turn[ConverseAPIFields.ROLE] == RolesEnum.ASSISTANT.value
+            tr = tool_result_turn[ConverseAPIFields.CONTENT][0][ConverseAPIFields.TOOL_RESULT]
+            assert tr[ConverseAPIFields.TOOL_USE_ID] == "tool-77"
+            assert tr[ConverseAPIFields.TOOL_RESULT_STATUS] == "success"
+            assert tr[ConverseAPIFields.TOOL_RESULT_CONTENT] == [
+                {ConverseAPIFields.TOOL_RESULT_JSON: {"temp_c": 18}}
+            ]
+
+            # Turn 2: send the loop back; the model returns the final answer.
+            second = manager.converse(
+                messages=[first_message, assistant_turn, tool_result_turn],
+                tool_config=tool_config,
+            )
+
+            assert second.success is True
+            assert second.has_tool_use() is False
+            assert second.get_tool_uses() == []
+            assert second.get_content() == "It is 18 degrees in Paris."
+
+        assert mock_client.converse.call_count == 2


### PR DESCRIPTION
Closes #31.

## Problem

`toolConfig` was already forwarded to boto3, so tools could be *declared* — but there was no fluent way to build a `toolUse`/`toolResult` turn and no typed accessor to read a tool call out of a response. Users had to drop to raw dicts on both ends, the exact thing the library exists to avoid.

## What this adds

**Build side — `ConverseMessageBuilder`:**
- `add_tool_use(tool_use_id, name, input)` → a `toolUse` content block (assistant turn). Validates non-empty id/name and dict input.
- `add_tool_result(tool_use_id, content, status=None)` → a `toolResult` block (user turn). `content` accepts a `str` (→ `text` result block), a `dict` (→ `json` result block), or a pre-built list of `ToolResultContentBlock`s (passed through — this is how image/document/video results are supplied). `status` is `ToolResultStatusEnum.SUCCESS`/`.ERROR` or the raw string, validated against the API's `success|error` values.

**Parse side — `BedrockResponse`:**
- `get_tool_uses()` → `List[ToolUse]` (typed `tool_use_id`, `name`, parsed `input`), built on the #41 `get_content_blocks_by_type(TOOL_USE)` iterator — non-streaming responses, not just streaming deltas.
- `has_tool_use()` → True when a `toolUse` block is present **or** `stopReason == tool_use`.

A frozen `ToolUse` dataclass and `ToolResultStatusEnum` (both exported from the package), plus the tool field-name/status constants.

## Design notes

- Shapes taken from the AWS Bedrock Runtime `ToolUseBlock` / `ToolResultBlock` / `ToolResultContentBlock` references (consulted via the AWS docs MCP server). `ToolResultContentBlock` is a union (text/json/image/document/video/searchResult); the str/dict ergonomic cases plus the pre-built-list passthrough cover it without the builder enumerating every media type. Rationale + alternatives in the spec decision log (DL-001/002).
- The parse side reuses #41's general iterator rather than re-deriving one — exactly the "build the type-specific accessors on top of the general mechanism" the #41 issue called for.

## Proof

- Unit tests: `test_tool_use.py` (ToolUse parsing), `test_message_builder.py::TestAddToolUseMethod`/`TestAddToolResultMethod` (build + validation, incl. empty/empty-list/wrong-type rejection), `test_bedrock_response.py::TestBedrockResponseToolUse` (typed parse + order, both `has_tool_use` paths), and a **mocked end-to-end two-turn tool loop** (`test_tool_use_roundtrip.py`) driving `LLMManager.converse` with a client that returns a `tool_use` turn then an `end_turn` turn.
- Full unit suite: **2717 passed, 7 skipped, 0 failed**. New `tool_use.py` at **100%** coverage.
- `ruff format --check` ✓, `ruff check` ✓, `mypy --exclude="_version" src/` ✓.
- Independently re-verified by an adversarial pass (9 mutation-based claims, 0 refuted; its one B-level note — three untested defensive error-branches — was then closed with three added tests).

No breaking changes.