### PR TITLE
Support reasoning / extended thinking (reasoningContent) build + parse round-trip (#32)

### DIFF
--- a/docs/forLLMConsumption.md
+++ b/docs/forLLMConsumption.md
@@ -273,6 +273,48 @@ if resp.has_tool_use():
     print(final.get_content())
 ```
 
+#### Reasoning / Extended Thinking Round-Trip
+
+```python
+def add_reasoning_content(
+    self, text: Optional[str] = None, signature: Optional[str] = None,
+    redacted_content: Optional[Any] = None,
+) -> 'ConverseMessageBuilder'
+```
+
+Reasoning-capable models (Claude extended thinking, Nova reasoning, DeepSeek-R1) return a
+`reasoningContent` block. The signed reasoning block must be echoed back **unmodified**
+(text + `signature`) in later turns of a multi-turn conversation. Read it with
+`BedrockResponse.get_reasoning()` (also on `StreamingResponse`, reconstructed from the
+streamed deltas), and replay it with `add_reasoning_content`:
+
+```python
+# Enable extended thinking via additional_model_request_fields (already supported).
+thinking = {"thinking": {"type": "enabled", "budget_tokens": 1024}}
+resp = manager.converse(messages=[msg], additional_model_request_fields=thinking)
+
+reasoning = resp.get_reasoning()          # ReasoningContent(text, signature, redacted_content) | None
+if reasoning is not None:
+    assistant_turn = create_assistant_message()\
+        .add_reasoning_content(text=reasoning.text, signature=reasoning.signature)\
+        .add_text("...assistant's visible answer...")\
+        .build()
+    # The signature is preserved verbatim, so the next turn validates.
+    follow_up = create_user_message().add_text("Now continue.").build()
+    nxt = manager.converse(
+        messages=[msg, assistant_turn, follow_up],
+        additional_model_request_fields=thinking,
+    )
+
+# ReasoningContent.to_content_block() also rebuilds the re-submittable block directly.
+```
+
+Response/StreamingResponse accessor:
+
+```python
+def get_reasoning(self) -> Optional[ReasoningContent]   # text + signature (+ redacted bytes), or None
+```
+
 #### Building Messages
 
 ```python

--- a/src/bestehorn_llmmanager/__init__.py
+++ b/src/bestehorn_llmmanager/__init__.py
@@ -48,6 +48,9 @@ from .bedrock.models.llm_manager_structures import Boto3Config
 # Model-specific configuration and tracking
 from .bedrock.models.model_specific_structures import ModelSpecificConfig
 
+# Reasoning / extended-thinking typed content
+from .bedrock.models.reasoning_content import ReasoningContent
+
 # Tool use (function calling) typed request object
 from .bedrock.models.tool_use import ToolUse
 from .bedrock.tracking.parameter_compatibility_tracker import ParameterCompatibilityTracker
@@ -111,6 +114,8 @@ __all__ = [
     "ResponseContentType",
     # Tool use (function calling)
     "ToolUse",
+    # Reasoning / extended thinking
+    "ReasoningContent",
     # Region utilities
     "BedrockRegionDiscovery",
     "get_all_regions",

--- a/src/bestehorn_llmmanager/bedrock/models/bedrock_response.py
+++ b/src/bestehorn_llmmanager/bedrock/models/bedrock_response.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Union
 from .content_block_types import ResponseContentType
 from .llm_manager_constants import ConverseAPIFields
 from .llm_manager_structures import RequestAttempt, ValidationAttempt
+from .reasoning_content import ReasoningContent
 from .stop_reason import StopReasonCategory, StopReasonClassifier
 from .tool_use import ToolUse
 
@@ -192,6 +193,29 @@ class BedrockResponse:
         if self.get_tool_uses():
             return True
         return self.get_stop_reason() == ConverseAPIFields.STOP_REASON_TOOL_USE
+
+    def get_reasoning(self) -> Optional["ReasoningContent"]:
+        """
+        Get the reasoning / extended-thinking content from the response, if any.
+
+        Parses the first ``reasoningContent`` block into a typed
+        :class:`~bestehorn_llmmanager.bedrock.models.reasoning_content.ReasoningContent`
+        (text + signature, or redacted bytes), so the reasoning can be read and echoed
+        back into a multi-turn request with its signature preserved. Built on
+        :meth:`get_content_blocks_by_type`.
+
+        Returns:
+            The :class:`ReasoningContent`, or ``None`` if the response contains no
+            reasoning block.
+        """
+        reasoning_blocks = self.get_content_blocks_by_type(
+            content_type=ResponseContentType.REASONING_CONTENT
+        )
+        if not reasoning_blocks:
+            return None
+        return ReasoningContent.from_reasoning_block(
+            reasoning_block=reasoning_blocks[0][ConverseAPIFields.REASONING_CONTENT]
+        )
 
     def get_content(self) -> Optional[str]:
         """
@@ -826,6 +850,11 @@ class StreamingResponse:
     current_message_role: Optional[str] = None
     request_attempt: Optional[RequestAttempt] = None
     warnings: List[str] = field(default_factory=list)
+    # Reasoning / extended-thinking accumulated across reasoningContent deltas (issue #32),
+    # so the final signed block can be reconstructed for multi-turn echo-back.
+    reasoning_text_parts: List[str] = field(default_factory=list)
+    reasoning_signature: Optional[str] = None
+    reasoning_redacted_content: Optional[Any] = None
 
     # Internal fields for iterator protocol
     _event_stream: Optional[Any] = field(default=None, init=False, repr=False)
@@ -990,6 +1019,18 @@ class StreamingResponse:
             self.current_message_role = processed_event.get(StreamingConstants.FIELD_ROLE)
 
         elif event_type == StreamingEventTypes.CONTENT_BLOCK_DELTA:
+            # Accumulate reasoning text / signature / redacted bytes so the final signed
+            # reasoningContent block can be reconstructed for echo-back (issue #32).
+            reasoning_text = processed_event.get("reasoning_text")
+            if reasoning_text:
+                self.reasoning_text_parts.append(reasoning_text)
+            reasoning_signature = processed_event.get("reasoning_signature")
+            if reasoning_signature:
+                self.reasoning_signature = reasoning_signature
+            reasoning_redacted = processed_event.get("reasoning_redacted_content")
+            if reasoning_redacted is not None:
+                self.reasoning_redacted_content = reasoning_redacted
+
             # Add content chunk and return it for real-time display
             content = processed_event.get("content", "")
             if content and isinstance(content, str):
@@ -1096,6 +1137,29 @@ class StreamingResponse:
             Complete content string
         """
         return "".join(self.content_parts)
+
+    def get_reasoning(self) -> Optional[ReasoningContent]:
+        """
+        Get the reasoning / extended-thinking content reconstructed from the stream.
+
+        Joins the ``reasoningContent`` text deltas and pairs them with the verification
+        signature (and any redacted bytes) captured during streaming, into a typed
+        :class:`~bestehorn_llmmanager.bedrock.models.reasoning_content.ReasoningContent`.
+        Its :meth:`ReasoningContent.to_content_block` rebuilds a re-submittable signed
+        block for multi-turn echo-back (issue #32).
+
+        Returns:
+            The :class:`ReasoningContent`, or ``None`` if the stream carried no reasoning.
+        """
+        if self.reasoning_text_parts:
+            return ReasoningContent(
+                text="".join(self.reasoning_text_parts),
+                signature=self.reasoning_signature,
+                redacted_content=self.reasoning_redacted_content,
+            )
+        if self.reasoning_redacted_content is not None:
+            return ReasoningContent(redacted_content=self.reasoning_redacted_content)
+        return None
 
     def get_content_parts(self) -> List[str]:
         """

--- a/src/bestehorn_llmmanager/bedrock/models/llm_manager_constants.py
+++ b/src/bestehorn_llmmanager/bedrock/models/llm_manager_constants.py
@@ -53,6 +53,11 @@ class ConverseAPIFields:
     # Document block fields
     NAME: Final[str] = "name"
 
+    # Reasoning content block fields (reasoningContent union)
+    REASONING_TEXT: Final[str] = "reasoningText"
+    REASONING_SIGNATURE: Final[str] = "signature"
+    REASONING_REDACTED_CONTENT: Final[str] = "redactedContent"
+
     # Tool use / tool result block fields
     TOOL_USE_ID: Final[str] = "toolUseId"
     TOOL_NAME: Final[str] = "name"

--- a/src/bestehorn_llmmanager/bedrock/models/reasoning_content.py
+++ b/src/bestehorn_llmmanager/bedrock/models/reasoning_content.py
@@ -1,0 +1,104 @@
+"""
+Typed reasoning / extended-thinking content for Bedrock Converse.
+
+Defines :class:`ReasoningContent`, the typed view of a ``reasoningContent`` block (the
+Chain-of-Thought a reasoning-capable model emits — Claude extended thinking, Nova
+reasoning, DeepSeek-R1). The block is a union of either ``reasoningText`` (``text`` plus
+a verification ``signature``) or encrypted ``redactedContent``. For correct multi-turn
+conversations the block must be echoed back **unmodified** (text + signature), so this
+class both parses a block from a response and reconstructs a re-submittable block.
+
+References:
+- ReasoningContentBlock (reasoningText | redactedContent):
+  https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlock.html
+- ReasoningTextBlock (text [required], signature [optional]):
+  https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningTextBlock.html
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from .llm_manager_constants import ConverseAPIFields
+
+
+@dataclass(frozen=True)
+class ReasoningContent:
+    """
+    A reasoning / extended-thinking content block from a response.
+
+    Exactly one of (text, redacted_content) is normally populated, matching the
+    ``reasoningContent`` union. When echoing reasoning back in a multi-turn request,
+    pass ``text`` and ``signature`` through unmodified.
+
+    Attributes:
+        text: The model's reasoning text (the ``reasoningText.text``), or ``None`` for a
+            redacted block.
+        signature: The token verifying the reasoning text was model-generated
+            (``reasoningText.signature``); must be echoed back unmodified. ``None`` if
+            the model did not provide one.
+        redacted_content: Encrypted reasoning bytes (the ``redactedContent`` member), or
+            ``None`` when the block carries reasoning text instead.
+    """
+
+    text: Optional[str] = None
+    signature: Optional[str] = None
+    redacted_content: Optional[Any] = None
+
+    @classmethod
+    def from_reasoning_block(cls, reasoning_block: Dict[str, Any]) -> "ReasoningContent":
+        """
+        Build a :class:`ReasoningContent` from a ``reasoningContent`` block payload.
+
+        Args:
+            reasoning_block: The value under a content block's ``reasoningContent`` key
+                — either ``{"reasoningText": {"text", "signature"?}}`` or
+                ``{"redactedContent": <bytes>}``.
+
+        Returns:
+            The typed :class:`ReasoningContent`.
+        """
+        reasoning_text = reasoning_block.get(ConverseAPIFields.REASONING_TEXT)
+        if isinstance(reasoning_text, dict):
+            return cls(
+                text=reasoning_text.get(ConverseAPIFields.TEXT),
+                signature=reasoning_text.get(ConverseAPIFields.REASONING_SIGNATURE),
+                redacted_content=reasoning_block.get(ConverseAPIFields.REASONING_REDACTED_CONTENT),
+            )
+        return cls(
+            text=None,
+            signature=None,
+            redacted_content=reasoning_block.get(ConverseAPIFields.REASONING_REDACTED_CONTENT),
+        )
+
+    def to_content_block(self) -> Dict[str, Any]:
+        """
+        Reconstruct the re-submittable ``reasoningContent`` content block.
+
+        Produces a block suitable for echoing back in a subsequent turn: a
+        ``reasoningText`` member (with the signature preserved when present) when the
+        reasoning is textual, or a ``redactedContent`` member when it is redacted.
+
+        Returns:
+            A content block dict ``{"reasoningContent": {...}}``.
+
+        Raises:
+            ValueError: If neither reasoning text nor redacted content is present.
+        """
+        if self.text is not None:
+            reasoning_text: Dict[str, Any] = {ConverseAPIFields.TEXT: self.text}
+            if self.signature is not None:
+                reasoning_text[ConverseAPIFields.REASONING_SIGNATURE] = self.signature
+            return {
+                ConverseAPIFields.REASONING_CONTENT: {
+                    ConverseAPIFields.REASONING_TEXT: reasoning_text
+                }
+            }
+        if self.redacted_content is not None:
+            return {
+                ConverseAPIFields.REASONING_CONTENT: {
+                    ConverseAPIFields.REASONING_REDACTED_CONTENT: self.redacted_content
+                }
+            }
+        raise ValueError(
+            "ReasoningContent has neither text nor redacted_content; cannot build a block."
+        )

--- a/src/bestehorn_llmmanager/bedrock/streaming/event_handlers.py
+++ b/src/bestehorn_llmmanager/bedrock/streaming/event_handlers.py
@@ -100,12 +100,22 @@ class StreamEventHandler:
 
         processed_delta = self._process_delta_content(delta=delta)
 
-        return {
+        result = {
             StreamingConstants.FIELD_DELTA: processed_delta,
             StreamingConstants.FIELD_CONTENT_BLOCK_INDEX: content_block_index,
             "event_type": StreamingEventTypes.CONTENT_BLOCK_DELTA,
             "content": processed_delta.get("content", ""),
         }
+        # Surface reasoning fields at the top level (like "content") so the
+        # StreamingResponse can accumulate them for echo-back reconstruction (issue #32).
+        for reasoning_key in (
+            "reasoning_text",
+            "reasoning_signature",
+            "reasoning_redacted_content",
+        ):
+            if reasoning_key in processed_delta:
+                result[reasoning_key] = processed_delta[reasoning_key]
+        return result
 
     def handle_content_block_stop(self, event: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -264,13 +274,21 @@ class StreamEventHandler:
             tool_input = tool_use[StreamingConstants.FIELD_INPUT]
             processed_delta["tool_input"] = tool_input
 
-        # Extract reasoning content
+        # Extract reasoning content (text, the verification signature, and any redacted
+        # bytes), so the final signed reasoningContent block can be reconstructed for
+        # multi-turn echo-back (issue #32).
         reasoning = delta.get(StreamingConstants.FIELD_REASONING_CONTENT)
         if reasoning:
             reasoning_text = reasoning.get(StreamingConstants.FIELD_TEXT)
             if reasoning_text:
                 content_parts.append(reasoning_text)
                 processed_delta["reasoning_text"] = reasoning_text
+            reasoning_signature = reasoning.get(StreamingConstants.FIELD_SIGNATURE)
+            if reasoning_signature:
+                processed_delta["reasoning_signature"] = reasoning_signature
+            reasoning_redacted = reasoning.get(StreamingConstants.FIELD_REDACTED_CONTENT)
+            if reasoning_redacted is not None:
+                processed_delta["reasoning_redacted_content"] = reasoning_redacted
 
         # Extract citation content
         citation = delta.get(StreamingConstants.FIELD_CITATION)

--- a/src/bestehorn_llmmanager/message_builder.py
+++ b/src/bestehorn_llmmanager/message_builder.py
@@ -778,6 +778,68 @@ class ConverseMessageBuilder:
                 f"Invalid tool_result status '{status}'. Valid values are: {valid}"
             ) from exc
 
+    def add_reasoning_content(
+        self,
+        text: Optional[str] = None,
+        signature: Optional[str] = None,
+        redacted_content: Optional[Any] = None,
+    ) -> "ConverseMessageBuilder":
+        """
+        Add a ``reasoningContent`` block (extended-thinking / Chain-of-Thought).
+
+        Use this to echo a model's reasoning back into a multi-turn request. For a
+        textual reasoning block, pass ``text`` and the ``signature`` returned by the
+        model **unmodified** — the signature verifies the reasoning was model-generated
+        and must be preserved. For an encrypted block, pass ``redacted_content`` instead.
+
+        Args:
+            text: The reasoning text (``reasoningText.text``). Required unless
+                ``redacted_content`` is given.
+            signature: The verification token to echo back unmodified
+                (``reasoningText.signature``). Only meaningful with ``text``.
+            redacted_content: Encrypted reasoning bytes (the ``redactedContent`` member),
+                used instead of ``text``.
+
+        Returns:
+            Self for method chaining.
+
+        Raises:
+            RequestValidationError: If neither ``text`` nor ``redacted_content`` is
+                provided, or ``text`` is empty/whitespace.
+        """
+        if text is None and redacted_content is None:
+            raise RequestValidationError(
+                MessageBuilderErrorMessages.EMPTY_CONTENT.format(
+                    content_type="reasoning_content (text or redacted_content required)"
+                )
+            )
+        if text is not None and not text.strip():
+            raise RequestValidationError(
+                MessageBuilderErrorMessages.EMPTY_CONTENT.format(content_type="reasoning text")
+            )
+
+        self._validate_content_block_limit()
+
+        reasoning_inner: Dict[str, Any] = {}
+        if text is not None:
+            reasoning_text: Dict[str, Any] = {ConverseAPIFields.TEXT: text}
+            if signature is not None:
+                reasoning_text[ConverseAPIFields.REASONING_SIGNATURE] = signature
+            reasoning_inner[ConverseAPIFields.REASONING_TEXT] = reasoning_text
+        else:
+            reasoning_inner[ConverseAPIFields.REASONING_REDACTED_CONTENT] = redacted_content
+
+        self._content_blocks.append({ConverseAPIFields.REASONING_CONTENT: reasoning_inner})
+        self._cacheable_blocks.append(False)
+
+        self._logger.debug(
+            MessageBuilderLogMessages.CONTENT_BLOCK_ADDED.format(
+                content_type="reasoning_content", size=len(str(reasoning_inner))
+            )
+        )
+
+        return self
+
     def build(self) -> Dict[str, Any]:
         """
         Build and return the complete message dictionary.

--- a/test/bestehorn_llmmanager/bedrock/models/test_bedrock_response.py
+++ b/test/bestehorn_llmmanager/bedrock/models/test_bedrock_response.py
@@ -591,6 +591,63 @@ class TestBedrockResponse:
         assert "FAILED" in repr_str
 
 
+class TestBedrockResponseReasoning:
+    """Tests for the reasoning response accessor (issue #32, non-streaming)."""
+
+    def _reasoning_response(self):
+        response_data = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "reasoningContent": {
+                                "reasoningText": {"text": "I deduce X", "signature": "sig-99"}
+                            }
+                        },
+                        {"text": "The answer is X."},
+                    ],
+                }
+            },
+            "stopReason": "end_turn",
+        }
+        return BedrockResponse(success=True, response_data=response_data)
+
+    def test_get_reasoning_returns_typed_object(self):
+        from bestehorn_llmmanager.bedrock.models.reasoning_content import ReasoningContent
+
+        reasoning = self._reasoning_response().get_reasoning()
+        assert isinstance(reasoning, ReasoningContent)
+        assert reasoning.text == "I deduce X"
+        assert reasoning.signature == "sig-99"
+
+    def test_get_reasoning_round_trips_to_resubmittable_block(self):
+        """The parsed reasoning rebuilds a block preserving text + signature."""
+        reasoning = self._reasoning_response().get_reasoning()
+        block = reasoning.to_content_block()
+        assert block["reasoningContent"]["reasoningText"]["signature"] == "sig-99"
+
+    def test_get_reasoning_none_when_absent(self):
+        response_data = {"output": {"message": {"content": [{"text": "no reasoning"}]}}}
+        response = BedrockResponse(success=True, response_data=response_data)
+        assert response.get_reasoning() is None
+
+    def test_get_reasoning_none_when_no_data(self):
+        assert BedrockResponse(success=True, response_data=None).get_reasoning() is None
+
+    def test_get_reasoning_redacted(self):
+        response_data = {
+            "output": {
+                "message": {"content": [{"reasoningContent": {"redactedContent": b"\x07\x08"}}]}
+            }
+        }
+        response = BedrockResponse(success=True, response_data=response_data)
+        reasoning = response.get_reasoning()
+        assert reasoning is not None
+        assert reasoning.text is None
+        assert reasoning.redacted_content == b"\x07\x08"
+
+
 class TestBedrockResponseToolUse:
     """Tests for the tool-use response accessors (issue #31)."""
 
@@ -1958,3 +2015,71 @@ class TestBedrockResponseTokenAccessorProperties:
             == response.get_input_tokens() + response.get_output_tokens()
         )
         assert response.get_total_tokens() == input_tokens + output_tokens
+
+
+class TestStreamingResponseReasoning:
+    """Reconstruct reasoning from streaming deltas, preserving the signature (issue #32)."""
+
+    def _drive(self, response, events):
+        """Run the real iterator over the given raw EventStream events to completion."""
+        response._stream_iterator = iter(events)
+        list(response)  # exhausts the iterator, exercising the real event handler
+
+    def test_streaming_reconstructs_reasoning_with_signature(self):
+        """reasoningContent text deltas + a signature delta rebuild a signed block."""
+        from bestehorn_llmmanager.bedrock.models.reasoning_content import ReasoningContent
+
+        response = StreamingResponse(success=True)
+        events = [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "I think "}}}},
+            {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "carefully"}}}},
+            {"contentBlockDelta": {"delta": {"reasoningContent": {"signature": "sig-stream"}}}},
+            {"contentBlockDelta": {"delta": {"text": "Final answer."}}},
+            {"messageStop": {"stopReason": "end_turn"}},
+        ]
+        self._drive(response=response, events=events)
+
+        reasoning = response.get_reasoning()
+        assert isinstance(reasoning, ReasoningContent)
+        assert reasoning.text == "I think carefully"
+        assert reasoning.signature == "sig-stream"
+
+        # The reconstructed block is re-submittable with the signature preserved.
+        block = reasoning.to_content_block()
+        assert block["reasoningContent"]["reasoningText"]["signature"] == "sig-stream"
+        assert block["reasoningContent"]["reasoningText"]["text"] == "I think carefully"
+
+    def test_streaming_no_reasoning_returns_none(self):
+        """A text-only stream yields no reasoning."""
+        response = StreamingResponse(success=True)
+        events = [
+            {"contentBlockDelta": {"delta": {"text": "just text"}}},
+            {"messageStop": {"stopReason": "end_turn"}},
+        ]
+        self._drive(response=response, events=events)
+        assert response.get_reasoning() is None
+
+    def test_streaming_reconstructs_redacted_reasoning(self):
+        """A redactedContent reasoning delta reconstructs a redacted ReasoningContent."""
+        from bestehorn_llmmanager.bedrock.models.reasoning_content import ReasoningContent
+
+        response = StreamingResponse(success=True)
+        events = [
+            {
+                "contentBlockDelta": {
+                    "delta": {"reasoningContent": {"redactedContent": b"\x10\x20"}}
+                }
+            },
+            {"contentBlockDelta": {"delta": {"text": "Visible answer."}}},
+            {"messageStop": {"stopReason": "end_turn"}},
+        ]
+        self._drive(response=response, events=events)
+
+        reasoning = response.get_reasoning()
+        assert isinstance(reasoning, ReasoningContent)
+        assert reasoning.text is None
+        assert reasoning.redacted_content == b"\x10\x20"
+        # The reconstructed block is a re-submittable redactedContent block.
+        block = reasoning.to_content_block()
+        assert block["reasoningContent"]["redactedContent"] == b"\x10\x20"

--- a/test/bestehorn_llmmanager/bedrock/models/test_reasoning_content.py
+++ b/test/bestehorn_llmmanager/bedrock/models/test_reasoning_content.py
@@ -1,0 +1,72 @@
+"""
+Tests for the ReasoningContent typed reasoning object (issue #32).
+"""
+
+import pytest
+
+from bestehorn_llmmanager.bedrock.models.reasoning_content import ReasoningContent
+
+
+class TestReasoningContentFromBlock:
+    """Parse ReasoningContent from a reasoningContent block payload."""
+
+    def test_from_reasoning_text_with_signature(self):
+        payload = {"reasoningText": {"text": "step by step", "signature": "sig-abc"}}
+        rc = ReasoningContent.from_reasoning_block(reasoning_block=payload)
+        assert rc.text == "step by step"
+        assert rc.signature == "sig-abc"
+        assert rc.redacted_content is None
+
+    def test_from_reasoning_text_without_signature(self):
+        payload = {"reasoningText": {"text": "thinking"}}
+        rc = ReasoningContent.from_reasoning_block(reasoning_block=payload)
+        assert rc.text == "thinking"
+        assert rc.signature is None
+
+    def test_from_redacted_content(self):
+        payload = {"redactedContent": b"\x01\x02"}
+        rc = ReasoningContent.from_reasoning_block(reasoning_block=payload)
+        assert rc.text is None
+        assert rc.signature is None
+        assert rc.redacted_content == b"\x01\x02"
+
+
+class TestReasoningContentToBlock:
+    """Reconstruct a re-submittable content block."""
+
+    def test_to_block_text_and_signature(self):
+        rc = ReasoningContent(text="step by step", signature="sig-abc")
+        block = rc.to_content_block()
+        assert block == {
+            "reasoningContent": {"reasoningText": {"text": "step by step", "signature": "sig-abc"}}
+        }
+
+    def test_to_block_text_no_signature(self):
+        rc = ReasoningContent(text="thinking")
+        block = rc.to_content_block()
+        assert block == {"reasoningContent": {"reasoningText": {"text": "thinking"}}}
+        assert "signature" not in block["reasoningContent"]["reasoningText"]
+
+    def test_to_block_redacted(self):
+        rc = ReasoningContent(redacted_content=b"\x01\x02")
+        block = rc.to_content_block()
+        assert block == {"reasoningContent": {"redactedContent": b"\x01\x02"}}
+
+    def test_to_block_empty_raises(self):
+        with pytest.raises(ValueError):
+            ReasoningContent().to_content_block()
+
+    def test_round_trip_preserves_signature(self):
+        """from_reasoning_block -> to_content_block preserves text and signature."""
+        original = {"reasoningText": {"text": "deduce", "signature": "sig-xyz"}}
+        rc = ReasoningContent.from_reasoning_block(reasoning_block=original)
+        rebuilt = rc.to_content_block()
+        assert rebuilt["reasoningContent"]["reasoningText"]["signature"] == "sig-xyz"
+        assert rebuilt["reasoningContent"]["reasoningText"]["text"] == "deduce"
+
+    def test_is_frozen(self):
+        import dataclasses
+
+        rc = ReasoningContent(text="x")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            rc.text = "y"  # type: ignore[misc]

--- a/test/bestehorn_llmmanager/test_init.py
+++ b/test/bestehorn_llmmanager/test_init.py
@@ -37,6 +37,9 @@ class TestPackageInit:
         assert hasattr(bestehorn_llmmanager, "ToolResultStatusEnum")
         assert hasattr(bestehorn_llmmanager, "ToolUse")
 
+        # Test reasoning / extended-thinking type
+        assert hasattr(bestehorn_llmmanager, "ReasoningContent")
+
     def test_version_handling_with_version_import_success(self):
         """Test version handling when _version import succeeds."""
         # This will use the actual _version.py file which should exist
@@ -105,6 +108,7 @@ class TestPackageInit:
             "ResponseContentType",
             "ToolResultStatusEnum",
             "ToolUse",
+            "ReasoningContent",
         ]
 
         assert hasattr(bestehorn_llmmanager, "__all__")

--- a/test/bestehorn_llmmanager/test_message_builder.py
+++ b/test/bestehorn_llmmanager/test_message_builder.py
@@ -1144,3 +1144,58 @@ class TestAddToolResultMethod:
         assert ConverseAPIFields.TOOL_USE in assistant[ConverseAPIFields.CONTENT][1]
         assert user[ConverseAPIFields.ROLE] == "user"
         assert ConverseAPIFields.TOOL_RESULT in user[ConverseAPIFields.CONTENT][0]
+
+
+class TestAddReasoningContentMethod:
+    """Test cases for MessageBuilder.add_reasoning_content (issue #32)."""
+
+    def test_add_reasoning_content_text_and_signature(self):
+        """A reasoningText block is built with the signature preserved."""
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.ASSISTANT)
+            .add_reasoning_content(text="step by step", signature="sig-abc")
+            .build()
+        )
+        block = message[ConverseAPIFields.CONTENT][0]
+        reasoning = block[ConverseAPIFields.REASONING_CONTENT]
+        reasoning_text = reasoning[ConverseAPIFields.REASONING_TEXT]
+        assert reasoning_text[ConverseAPIFields.TEXT] == "step by step"
+        assert reasoning_text[ConverseAPIFields.REASONING_SIGNATURE] == "sig-abc"
+
+    def test_add_reasoning_content_text_without_signature(self):
+        """The signature key is omitted when no signature is supplied."""
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.ASSISTANT)
+            .add_reasoning_content(text="thinking")
+            .build()
+        )
+        reasoning_text = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.REASONING_CONTENT][
+            ConverseAPIFields.REASONING_TEXT
+        ]
+        assert reasoning_text[ConverseAPIFields.TEXT] == "thinking"
+        assert ConverseAPIFields.REASONING_SIGNATURE not in reasoning_text
+
+    def test_add_reasoning_content_redacted(self):
+        """A redactedContent block is built when only redacted_content is supplied."""
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.ASSISTANT)
+            .add_reasoning_content(redacted_content=b"\x01\x02")
+            .build()
+        )
+        reasoning = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.REASONING_CONTENT]
+        assert reasoning[ConverseAPIFields.REASONING_REDACTED_CONTENT] == b"\x01\x02"
+
+    def test_add_reasoning_content_returns_self(self):
+        """add_reasoning_content returns the builder for chaining."""
+        builder = ConverseMessageBuilder(role=RolesEnum.ASSISTANT)
+        assert builder.add_reasoning_content(text="x") is builder
+
+    def test_add_reasoning_content_requires_text_or_redacted(self):
+        """Calling with neither text nor redacted_content is rejected."""
+        with pytest.raises(RequestValidationError):
+            ConverseMessageBuilder(role=RolesEnum.ASSISTANT).add_reasoning_content()
+
+    def test_add_reasoning_content_empty_text_rejected(self):
+        """An empty/whitespace text is rejected."""
+        with pytest.raises(RequestValidationError):
+            ConverseMessageBuilder(role=RolesEnum.ASSISTANT).add_reasoning_content(text="   ")

--- a/test/bestehorn_llmmanager/test_reasoning_roundtrip.py
+++ b/test/bestehorn_llmmanager/test_reasoning_roundtrip.py
@@ -1,0 +1,120 @@
+"""
+Multi-turn reasoning round-trip test for issue #32 (mocked, no AWS).
+
+Verifies that a reasoning block parsed from a model response can be echoed back into a
+subsequent turn with its signature preserved verbatim — the property that makes
+multi-turn extended-thinking conversations valid. Exercises the public surface
+(LLMManager.converse + MessageBuilder.add_reasoning_content + BedrockResponse.get_reasoning)
+end to end with a mocked Bedrock client.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from bestehorn_llmmanager import LLMManager, create_assistant_message, create_user_message
+from bestehorn_llmmanager.bedrock.models.llm_manager_constants import ConverseAPIFields
+
+
+@pytest.fixture
+def mock_bedrock_catalog():
+    catalog = Mock()
+    catalog.get_model_info.return_value = Mock(
+        model_id="test-model-id",
+        has_direct_access=True,
+        has_regional_cris=False,
+        has_global_cris=False,
+        regional_cris_profile_id=None,
+        global_cris_profile_id=None,
+    )
+    catalog.is_model_available.return_value = True
+    return catalog
+
+
+@pytest.fixture
+def manager(mock_bedrock_catalog):
+    with patch(
+        "bestehorn_llmmanager.llm_manager.BedrockModelCatalog",
+        return_value=mock_bedrock_catalog,
+    ):
+        return LLMManager(models=["Claude Haiku 4 5 20251001"], regions=["us-east-1"])
+
+
+class TestReasoningRoundTripMocked:
+    """Parse reasoning from turn 1, echo it back unmodified into turn 2."""
+
+    def test_signature_preserved_across_turns(self, manager):
+        reasoning_turn = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "reasoningContent": {
+                                "reasoningText": {
+                                    "text": "Let me reason about this.",
+                                    "signature": "sig-multiturn-123",
+                                }
+                            }
+                        },
+                        {"text": "Partial answer."},
+                    ],
+                }
+            },
+            "stopReason": "end_turn",
+        }
+        final_turn = {
+            "output": {"message": {"role": "assistant", "content": [{"text": "Done."}]}},
+            "stopReason": "end_turn",
+        }
+        mock_client = Mock()
+        mock_client.converse.side_effect = [reasoning_turn, final_turn]
+
+        # Extended thinking is enabled via additional_model_request_fields (already
+        # supported by the library) — passed through to the mocked client here.
+        thinking_fields = {"thinking": {"type": "enabled", "budget_tokens": 1024}}
+
+        with patch.object(manager._auth_manager, "get_bedrock_client", return_value=mock_client):
+            first_message = create_user_message().add_text("Solve this.").build()
+            first = manager.converse(
+                messages=[first_message],
+                additional_model_request_fields=thinking_fields,
+            )
+
+            reasoning = first.get_reasoning()
+            assert reasoning is not None
+            assert reasoning.signature == "sig-multiturn-123"
+
+            # Echo the reasoning back unmodified, plus a follow-up user turn.
+            assistant_turn = (
+                create_assistant_message()
+                .add_reasoning_content(text=reasoning.text, signature=reasoning.signature)
+                .add_text("Partial answer.")
+                .build()
+            )
+            follow_up = create_user_message().add_text("Now finish.").build()
+
+            # The echoed block carries the signature verbatim.
+            reasoning_block = assistant_turn[ConverseAPIFields.CONTENT][0][
+                ConverseAPIFields.REASONING_CONTENT
+            ][ConverseAPIFields.REASONING_TEXT]
+            assert reasoning_block[ConverseAPIFields.REASONING_SIGNATURE] == "sig-multiturn-123"
+            assert reasoning_block[ConverseAPIFields.TEXT] == "Let me reason about this."
+
+            second = manager.converse(
+                messages=[first_message, assistant_turn, follow_up],
+                additional_model_request_fields=thinking_fields,
+            )
+            assert second.success is True
+            assert second.get_content() == "Done."
+
+        # Verify the echoed-back reasoning reached the API on the second call.
+        assert mock_client.converse.call_count == 2
+        second_call_messages = mock_client.converse.call_args_list[1].kwargs["messages"]
+        echoed = second_call_messages[1][ConverseAPIFields.CONTENT][0]
+        assert (
+            echoed[ConverseAPIFields.REASONING_CONTENT][ConverseAPIFields.REASONING_TEXT][
+                ConverseAPIFields.REASONING_SIGNATURE
+            ]
+            == "sig-multiturn-123"
+        )


### PR DESCRIPTION
Closes #32.

## Problem

Reasoning / extended thinking (Claude 3.7+ extended thinking, Nova reasoning, DeepSeek-R1) had no typed surface: there was no way to build a `reasoningContent` block back into a multi-turn conversation, and no accessor to read reasoning from a non-streaming response. Because the signed `reasoningText` block must be echoed back **verbatim** (text + `signature`) in later turns, this blocked correct multi-turn reasoning conversations. Streaming captured reasoning text deltas but dropped the signature, so even streamed reasoning could not be re-submitted validly.

## What this adds

- **`MessageBuilder.add_reasoning_content(text=None, signature=None, redacted_content=None)`** — builds a `reasoningContent` block for echo-back: `reasoningText{text[, signature]}` for textual reasoning (signature preserved), or `redactedContent` for encrypted reasoning. Rejects neither-given and empty text.
- **`BedrockResponse.get_reasoning()`** — returns a typed `ReasoningContent(text, signature, redacted_content)` parsed via the #41 `get_content_blocks_by_type(REASONING_CONTENT)` iterator (non-streaming).
- **`StreamingResponse.get_reasoning()`** — reconstructs the reasoning from streamed deltas. The streaming event handler now captures the `signature` and `redactedContent` (not just text) and surfaces them so `StreamingResponse` accumulates them into a re-submittable block.
- **`ReasoningContent`** — a frozen dataclass (exported from the package) with `from_reasoning_block()` and `to_content_block()` (rebuilds the signed re-submittable block). Plus the `reasoningContent` field constants.

## Design notes

- Shapes from the AWS Bedrock Runtime `ReasoningContentBlock` (union `reasoningText` | `redactedContent`) and `ReasoningTextBlock` (`text` required, `signature` optional; docs: "include the text and its signature unmodified" for multi-turn), consulted via the AWS docs MCP server. Extended thinking is enabled via `additional_model_request_fields` (already supported) — the docs show the full pattern.
- A typed object is required (not a plain string) precisely so the signature round-trips unmodified. Rationale + alternatives in the spec decision log (DL-001/002/003).

## Proof

- Unit tests: `test_reasoning_content.py` (parse/rebuild/round-trip/frozen), `test_message_builder.py::TestAddReasoningContentMethod` (block shapes + validation), `test_bedrock_response.py::TestBedrockResponseReasoning` (non-streaming parse + redacted) and `::TestStreamingResponseReasoning` (streaming reconstruction of **text+signature** and **redacted**, driving the real iterator/event handler), and **`test_reasoning_roundtrip.py`** — a mocked multi-turn `LLMManager.converse` loop asserting the signature reaches the second `converse` call **verbatim**.
- Full unit suite: **2743 passed, 7 skipped, 0 failed**. New `reasoning_content.py` at **100%** coverage.
- `ruff format --check` ✓, `ruff check` ✓, `mypy --exclude="_version" src/` ✓.
- Independently adversarially verified: 8 of 9 mutation-based claims survived on the first pass; the 1 refuted claim (an untested streaming-redacted sub-path) was then closed with a dedicated test (DL-003).

No breaking changes; the streaming handler change preserves all existing streaming behavior (84 streaming/#31/#41 accessor tests pass).