### PR TITLE
Support document citations (DocumentBlock citations/context + citationsContent parsing) (#40)

### DIFF
--- a/docs/forLLMConsumption.md
+++ b/docs/forLLMConsumption.md
@@ -315,6 +315,40 @@ Response/StreamingResponse accessor:
 def get_reasoning(self) -> Optional[ReasoningContent]   # text + signature (+ redacted bytes), or None
 ```
 
+#### Document Citations
+
+Enable citations on a document so the model returns `citationsContent` linking its
+answer back to the source spans, then read them with `get_citations()`:
+
+```python
+def add_document_bytes(
+    self, bytes: bytes, format=None, filename=None, name=None,
+    citations_enabled: bool = False, context: Optional[str] = None,
+) -> 'ConverseMessageBuilder'
+# (add_local_document forwards citations_enabled / context too)
+```
+
+```python
+message = create_user_message()\
+    .add_text("Summarize the revenue trend, citing the source.")\
+    .add_local_document(
+        "annual_report.pdf",
+        citations_enabled=True,
+        context="Financial report for fiscal year 2025.",
+    )\
+    .build()
+response = manager.converse(messages=[message])
+
+for c in response.get_citations():     # List[Citation]
+    print(c.title, c.source, c.source_content, c.location)
+```
+
+Response/StreamingResponse accessor:
+
+```python
+def get_citations(self) -> List[Citation]   # typed (title, source, source_content, location)
+```
+
 #### Building Messages
 
 ```python

--- a/src/bestehorn_llmmanager/__init__.py
+++ b/src/bestehorn_llmmanager/__init__.py
@@ -39,6 +39,9 @@ For detailed documentation, see the documentation in the docs/ directory.
 from .bedrock.discovery import BedrockRegionDiscovery
 from .bedrock.models.aws_regions import AWSRegions, get_all_regions
 
+# Document citations typed reference
+from .bedrock.models.citation import Citation
+
 # Response content-block typing (typed iteration over response modalities)
 from .bedrock.models.content_block_types import ResponseContentType
 
@@ -116,6 +119,8 @@ __all__ = [
     "ToolUse",
     # Reasoning / extended thinking
     "ReasoningContent",
+    # Document citations
+    "Citation",
     # Region utilities
     "BedrockRegionDiscovery",
     "get_all_regions",

--- a/src/bestehorn_llmmanager/bedrock/models/bedrock_response.py
+++ b/src/bestehorn_llmmanager/bedrock/models/bedrock_response.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from .citation import Citation
 from .content_block_types import ResponseContentType
 from .llm_manager_constants import ConverseAPIFields
 from .llm_manager_structures import RequestAttempt, ValidationAttempt
@@ -216,6 +217,30 @@ class BedrockResponse:
         return ReasoningContent.from_reasoning_block(
             reasoning_block=reasoning_blocks[0][ConverseAPIFields.REASONING_CONTENT]
         )
+
+    def get_citations(self) -> List[Citation]:
+        """
+        Get the document citations from the response, in order.
+
+        When document citations are enabled (via the document builder's
+        ``citations_enabled``), the model returns ``citationsContent`` blocks whose
+        ``citations`` arrays reference the source spans. This flattens every
+        ``citationsContent`` block's citations into typed :class:`Citation` objects
+        (source title / location / referenced spans), built on
+        :meth:`get_content_blocks_by_type`.
+
+        Returns:
+            The ordered list of :class:`Citation`; an empty list if the response
+            contains no citations.
+        """
+        citations: List[Citation] = []
+        for block in self.get_content_blocks_by_type(
+            content_type=ResponseContentType.CITATIONS_CONTENT
+        ):
+            citations_content = block[ConverseAPIFields.CITATIONS_CONTENT]
+            for raw_citation in citations_content.get(ConverseAPIFields.CITATIONS, []) or []:
+                citations.append(Citation.from_citation(citation=raw_citation))
+        return citations
 
     def get_content(self) -> Optional[str]:
         """
@@ -855,6 +880,8 @@ class StreamingResponse:
     reasoning_text_parts: List[str] = field(default_factory=list)
     reasoning_signature: Optional[str] = None
     reasoning_redacted_content: Optional[Any] = None
+    # Document citations accumulated across citation deltas (issue #40).
+    citation_blocks: List[Dict[str, Any]] = field(default_factory=list)
 
     # Internal fields for iterator protocol
     _event_stream: Optional[Any] = field(default=None, init=False, repr=False)
@@ -1031,6 +1058,12 @@ class StreamingResponse:
             if reasoning_redacted is not None:
                 self.reasoning_redacted_content = reasoning_redacted
 
+            # Accumulate document citations so get_citations() can return typed
+            # Citation references after streaming (issue #40).
+            citation = processed_event.get("citation")
+            if citation:
+                self.citation_blocks.append(citation)
+
             # Add content chunk and return it for real-time display
             content = processed_event.get("content", "")
             if content and isinstance(content, str):
@@ -1160,6 +1193,19 @@ class StreamingResponse:
         if self.reasoning_redacted_content is not None:
             return ReasoningContent(redacted_content=self.reasoning_redacted_content)
         return None
+
+    def get_citations(self) -> List[Citation]:
+        """
+        Get the document citations accumulated from the stream, in order.
+
+        Each citation object captured from the ``citation`` deltas is parsed into a typed
+        :class:`~bestehorn_llmmanager.bedrock.models.citation.Citation` (issue #40).
+
+        Returns:
+            The ordered list of :class:`Citation`; an empty list if the stream carried
+            no citations.
+        """
+        return [Citation.from_citation(citation=block) for block in self.citation_blocks]
 
     def get_content_parts(self) -> List[str]:
         """

--- a/src/bestehorn_llmmanager/bedrock/models/citation.py
+++ b/src/bestehorn_llmmanager/bedrock/models/citation.py
@@ -1,0 +1,62 @@
+"""
+Typed document citation parsed from a Bedrock Converse response.
+
+Defines :class:`Citation`, the typed view of a single ``Citation`` returned inside a
+``citationsContent`` block when document citations are enabled, so callers can read the
+source title / location / referenced spans without hand-navigating the raw response dict.
+
+References:
+- CitationsContentBlock (citations[], content[]):
+  https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CitationsContentBlock.html
+- Citation (title, source, sourceContent[], location):
+  https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Citation.html
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .llm_manager_constants import ConverseAPIFields
+
+
+@dataclass(frozen=True)
+class Citation:
+    """
+    A single citation referencing a source document.
+
+    Provides traceability between the model's generated content and the source documents
+    that informed it.
+
+    Attributes:
+        title: The title or identifier of the cited source document, if provided.
+        source: The source (from the original search result) that provided the cited
+            content, if provided.
+        source_content: The specific source spans that were referenced — a list of
+            ``CitationSourceContent`` dicts (typically ``{"text": ...}``).
+        location: The precise location within the source document (a ``CitationLocation``
+            union dict — character positions, page numbers, or chunk identifiers), if
+            provided.
+    """
+
+    title: Optional[str] = None
+    source: Optional[str] = None
+    source_content: List[Dict[str, Any]] = field(default_factory=list)
+    location: Optional[Dict[str, Any]] = None
+
+    @classmethod
+    def from_citation(cls, citation: Dict[str, Any]) -> "Citation":
+        """
+        Build a :class:`Citation` from a raw ``Citation`` dict.
+
+        Args:
+            citation: A single ``Citation`` object from a ``citationsContent`` block.
+
+        Returns:
+            The typed :class:`Citation`. Missing fields default to ``None`` / empty list.
+        """
+        source_content = citation.get(ConverseAPIFields.CITATION_SOURCE_CONTENT) or []
+        return cls(
+            title=citation.get(ConverseAPIFields.CITATION_TITLE),
+            source=citation.get(ConverseAPIFields.CITATION_SOURCE),
+            source_content=list(source_content),
+            location=citation.get(ConverseAPIFields.CITATION_LOCATION),
+        )

--- a/src/bestehorn_llmmanager/bedrock/models/llm_manager_constants.py
+++ b/src/bestehorn_llmmanager/bedrock/models/llm_manager_constants.py
@@ -52,6 +52,15 @@ class ConverseAPIFields:
 
     # Document block fields
     NAME: Final[str] = "name"
+    CITATIONS: Final[str] = "citations"
+    CONTEXT: Final[str] = "context"
+    ENABLED: Final[str] = "enabled"
+
+    # Citations content block fields (citationsContent + Citation)
+    CITATION_TITLE: Final[str] = "title"
+    CITATION_SOURCE: Final[str] = "source"
+    CITATION_SOURCE_CONTENT: Final[str] = "sourceContent"
+    CITATION_LOCATION: Final[str] = "location"
 
     # Reasoning content block fields (reasoningContent union)
     REASONING_TEXT: Final[str] = "reasoningText"

--- a/src/bestehorn_llmmanager/bedrock/streaming/event_handlers.py
+++ b/src/bestehorn_llmmanager/bedrock/streaming/event_handlers.py
@@ -115,6 +115,10 @@ class StreamEventHandler:
         ):
             if reasoning_key in processed_delta:
                 result[reasoning_key] = processed_delta[reasoning_key]
+        # Surface the full citation object so the StreamingResponse can reconstruct
+        # typed Citation references for get_citations() (issue #40).
+        if "citation" in processed_delta:
+            result["citation"] = processed_delta["citation"]
         return result
 
     def handle_content_block_stop(self, event: Dict[str, Any]) -> Dict[str, Any]:
@@ -290,7 +294,10 @@ class StreamEventHandler:
             if reasoning_redacted is not None:
                 processed_delta["reasoning_redacted_content"] = reasoning_redacted
 
-        # Extract citation content
+        # Extract citation content. Keep the title shortcut for backward compatibility;
+        # the full citation object already flows through via `processed_delta = delta.copy()`
+        # above and is surfaced to the top level by handle_content_block_delta so the
+        # StreamingResponse can reconstruct typed Citation references (issue #40).
         citation = delta.get(StreamingConstants.FIELD_CITATION)
         if citation:
             citation_title = citation.get(StreamingConstants.FIELD_TITLE)

--- a/src/bestehorn_llmmanager/message_builder.py
+++ b/src/bestehorn_llmmanager/message_builder.py
@@ -258,6 +258,8 @@ class ConverseMessageBuilder:
         format: Optional[DocumentFormatEnum] = None,
         filename: Optional[str] = None,
         name: Optional[str] = None,
+        citations_enabled: bool = False,
+        context: Optional[str] = None,
     ) -> "ConverseMessageBuilder":
         """
         Add a document content block to the message.
@@ -267,6 +269,11 @@ class ConverseMessageBuilder:
             format: Optional document format (auto-detected if not provided)
             filename: Optional filename for format detection and logging
             name: Optional document name for the API
+            citations_enabled: When True, adds ``citations: {"enabled": True}`` so the
+                model returns ``citationsContent`` referencing the source spans (read it
+                with :meth:`BedrockResponse.get_citations`).
+            context: Optional contextual string telling the model how to process the
+                document when generating citations (the ``context`` field).
 
         Returns:
             Self for method chaining
@@ -348,6 +355,14 @@ class ConverseMessageBuilder:
             # Use filename as document name if no explicit name provided
             document_block[ConverseAPIFields.DOCUMENT][ConverseAPIFields.NAME] = filename
 
+        # Enable document citations and/or attach citation context (issue #40).
+        if citations_enabled:
+            document_block[ConverseAPIFields.DOCUMENT][ConverseAPIFields.CITATIONS] = {
+                ConverseAPIFields.ENABLED: True
+            }
+        if context is not None:
+            document_block[ConverseAPIFields.DOCUMENT][ConverseAPIFields.CONTEXT] = context
+
         self._content_blocks.append(document_block)
 
         self._logger.debug(
@@ -364,6 +379,8 @@ class ConverseMessageBuilder:
         format: Optional[DocumentFormatEnum] = None,
         name: Optional[str] = None,
         max_size_mb: float = 4.5,
+        citations_enabled: bool = False,
+        context: Optional[str] = None,
     ) -> "ConverseMessageBuilder":
         """
         Add a document content block from a local file path.
@@ -373,6 +390,9 @@ class ConverseMessageBuilder:
             format: Optional document format (auto-detected if not provided)
             name: Optional document name for the API
             max_size_mb: Maximum allowed size in MB
+            citations_enabled: When True, enables document citations (see
+                :meth:`add_document_bytes`).
+            context: Optional citation context string (see :meth:`add_document_bytes`).
 
         Returns:
             Self for method chaining
@@ -415,7 +435,12 @@ class ConverseMessageBuilder:
 
         # Use the existing add_document_bytes method
         return self.add_document_bytes(
-            bytes=document_bytes, format=format, filename=file_path.name, name=name
+            bytes=document_bytes,
+            format=format,
+            filename=file_path.name,
+            name=name,
+            citations_enabled=citations_enabled,
+            context=context,
         )
 
     def add_video_bytes(

--- a/test/bestehorn_llmmanager/bedrock/models/test_bedrock_response.py
+++ b/test/bestehorn_llmmanager/bedrock/models/test_bedrock_response.py
@@ -591,6 +591,78 @@ class TestBedrockResponse:
         assert "FAILED" in repr_str
 
 
+class TestBedrockResponseCitations:
+    """Tests for the document-citation response accessor (issue #40, non-streaming)."""
+
+    def _citations_response(self):
+        response_data = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"text": "Revenue grew 12% year over year."},
+                        {
+                            "citationsContent": {
+                                "content": [{"text": "Revenue grew 12% year over year."}],
+                                "citations": [
+                                    {
+                                        "title": "Annual Report",
+                                        "source": "doc-1",
+                                        "sourceContent": [{"text": "Revenue +12%."}],
+                                        "location": {"documentChar": {"start": 10, "end": 23}},
+                                    }
+                                ],
+                            }
+                        },
+                    ],
+                }
+            }
+        }
+        return BedrockResponse(success=True, response_data=response_data)
+
+    def test_get_citations_returns_typed_objects(self):
+        from bestehorn_llmmanager.bedrock.models.citation import Citation
+
+        citations = self._citations_response().get_citations()
+        assert len(citations) == 1
+        assert isinstance(citations[0], Citation)
+        assert citations[0].title == "Annual Report"
+        assert citations[0].source == "doc-1"
+        assert citations[0].source_content == [{"text": "Revenue +12%."}]
+        assert citations[0].location == {"documentChar": {"start": 10, "end": 23}}
+
+    def test_get_citations_flattens_multiple_blocks(self):
+        """Citations from multiple citationsContent blocks are returned in order."""
+        response_data = {
+            "output": {
+                "message": {
+                    "content": [
+                        {"citationsContent": {"citations": [{"title": "A"}]}},
+                        {"citationsContent": {"citations": [{"title": "B"}, {"title": "C"}]}},
+                    ]
+                }
+            }
+        }
+        response = BedrockResponse(success=True, response_data=response_data)
+        assert [c.title for c in response.get_citations()] == ["A", "B", "C"]
+
+    def test_get_citations_empty_when_absent(self):
+        response_data = {"output": {"message": {"content": [{"text": "no citations"}]}}}
+        response = BedrockResponse(success=True, response_data=response_data)
+        assert response.get_citations() == []
+
+    def test_get_citations_empty_when_no_data(self):
+        assert BedrockResponse(success=True, response_data=None).get_citations() == []
+
+    def test_get_citations_block_without_citations_key(self):
+        """A citationsContent block with no citations array yields no citations."""
+        response_data = {
+            "output": {"message": {"content": [{"citationsContent": {"content": []}}]}}
+        }
+        response = BedrockResponse(success=True, response_data=response_data)
+        assert response.get_citations() == []
+
+
 class TestBedrockResponseReasoning:
     """Tests for the reasoning response accessor (issue #32, non-streaming)."""
 
@@ -2083,3 +2155,47 @@ class TestStreamingResponseReasoning:
         # The reconstructed block is a re-submittable redactedContent block.
         block = reasoning.to_content_block()
         assert block["reasoningContent"]["redactedContent"] == b"\x10\x20"
+
+
+class TestStreamingResponseCitations:
+    """Reconstruct typed citations from streaming citation deltas (issue #40)."""
+
+    def _drive(self, response, events):
+        response._stream_iterator = iter(events)
+        list(response)
+
+    def test_streaming_collects_citations(self):
+        from bestehorn_llmmanager.bedrock.models.citation import Citation
+
+        response = StreamingResponse(success=True)
+        events = [
+            {"contentBlockDelta": {"delta": {"text": "Revenue grew."}}},
+            {
+                "contentBlockDelta": {
+                    "delta": {
+                        "citation": {
+                            "title": "Annual Report",
+                            "source": "doc-1",
+                            "sourceContent": [{"text": "Revenue +12%."}],
+                        }
+                    }
+                }
+            },
+            {"messageStop": {"stopReason": "end_turn"}},
+        ]
+        self._drive(response=response, events=events)
+
+        citations = response.get_citations()
+        assert len(citations) == 1
+        assert isinstance(citations[0], Citation)
+        assert citations[0].title == "Annual Report"
+        assert citations[0].source == "doc-1"
+
+    def test_streaming_no_citations_returns_empty(self):
+        response = StreamingResponse(success=True)
+        events = [
+            {"contentBlockDelta": {"delta": {"text": "no citations"}}},
+            {"messageStop": {"stopReason": "end_turn"}},
+        ]
+        self._drive(response=response, events=events)
+        assert response.get_citations() == []

--- a/test/bestehorn_llmmanager/bedrock/models/test_citation.py
+++ b/test/bestehorn_llmmanager/bedrock/models/test_citation.py
@@ -1,0 +1,43 @@
+"""
+Tests for the Citation typed document-citation object (issue #40).
+"""
+
+from bestehorn_llmmanager.bedrock.models.citation import Citation
+
+
+class TestCitationFromCitation:
+    """Parse a Citation from a raw Citation dict."""
+
+    def test_full_citation(self):
+        raw = {
+            "title": "Annual Report",
+            "source": "doc-1",
+            "sourceContent": [{"text": "Revenue grew 12%."}],
+            "location": {"documentChar": {"start": 100, "end": 117}},
+        }
+        citation = Citation.from_citation(citation=raw)
+        assert citation.title == "Annual Report"
+        assert citation.source == "doc-1"
+        assert citation.source_content == [{"text": "Revenue grew 12%."}]
+        assert citation.location == {"documentChar": {"start": 100, "end": 117}}
+
+    def test_minimal_citation(self):
+        citation = Citation.from_citation(citation={"title": "Doc"})
+        assert citation.title == "Doc"
+        assert citation.source is None
+        assert citation.source_content == []
+        assert citation.location is None
+
+    def test_empty_citation(self):
+        citation = Citation.from_citation(citation={})
+        assert citation.title is None
+        assert citation.source_content == []
+
+    def test_is_frozen(self):
+        import dataclasses
+
+        import pytest
+
+        citation = Citation(title="Doc")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            citation.title = "Other"  # type: ignore[misc]

--- a/test/bestehorn_llmmanager/test_init.py
+++ b/test/bestehorn_llmmanager/test_init.py
@@ -40,6 +40,9 @@ class TestPackageInit:
         # Test reasoning / extended-thinking type
         assert hasattr(bestehorn_llmmanager, "ReasoningContent")
 
+        # Test document-citation type
+        assert hasattr(bestehorn_llmmanager, "Citation")
+
     def test_version_handling_with_version_import_success(self):
         """Test version handling when _version import succeeds."""
         # This will use the actual _version.py file which should exist
@@ -109,6 +112,7 @@ class TestPackageInit:
             "ToolResultStatusEnum",
             "ToolUse",
             "ReasoningContent",
+            "Citation",
         ]
 
         assert hasattr(bestehorn_llmmanager, "__all__")

--- a/test/bestehorn_llmmanager/test_message_builder.py
+++ b/test/bestehorn_llmmanager/test_message_builder.py
@@ -651,6 +651,8 @@ class TestAddLocalDocumentMethod:
                     format=None,
                     filename=Path(tmp_file_path).name,
                     name="Test Document",
+                    citations_enabled=False,
+                    context=None,
                 )
         finally:
             Path(tmp_file_path).unlink(missing_ok=True)
@@ -1199,3 +1201,91 @@ class TestAddReasoningContentMethod:
         """An empty/whitespace text is rejected."""
         with pytest.raises(RequestValidationError):
             ConverseMessageBuilder(role=RolesEnum.ASSISTANT).add_reasoning_content(text="   ")
+
+
+class TestDocumentCitations:
+    """Document builder citations / context support (issue #40)."""
+
+    def test_citations_enabled_adds_citations_config(self):
+        """citations_enabled=True adds a citations.enabled=True config to the doc block."""
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.USER)
+            .add_document_bytes(
+                bytes=b"%PDF-1.4", format=DocumentFormatEnum.PDF, citations_enabled=True
+            )
+            .build()
+        )
+        document = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.DOCUMENT]
+        assert document[ConverseAPIFields.CITATIONS] == {ConverseAPIFields.ENABLED: True}
+
+    def test_context_adds_context_field(self):
+        """A context string is added to the document block."""
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.USER)
+            .add_document_bytes(
+                bytes=b"%PDF-1.4",
+                format=DocumentFormatEnum.PDF,
+                context="Summarize the financials.",
+            )
+            .build()
+        )
+        document = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.DOCUMENT]
+        assert document[ConverseAPIFields.CONTEXT] == "Summarize the financials."
+
+    def test_citations_and_context_together(self):
+        """Both citations and context can be set on the same document."""
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.USER)
+            .add_document_bytes(
+                bytes=b"%PDF-1.4",
+                format=DocumentFormatEnum.PDF,
+                citations_enabled=True,
+                context="ctx",
+            )
+            .build()
+        )
+        document = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.DOCUMENT]
+        assert document[ConverseAPIFields.CITATIONS] == {ConverseAPIFields.ENABLED: True}
+        assert document[ConverseAPIFields.CONTEXT] == "ctx"
+
+    def test_no_citations_by_default(self):
+        """By default neither citations nor context is added (backward compatible)."""
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.USER)
+            .add_document_bytes(bytes=b"%PDF-1.4", format=DocumentFormatEnum.PDF)
+            .build()
+        )
+        document = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.DOCUMENT]
+        assert ConverseAPIFields.CITATIONS not in document
+        assert ConverseAPIFields.CONTEXT not in document
+
+    def test_citations_disabled_explicitly_omitted(self):
+        """citations_enabled=False does not add a citations config."""
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.USER)
+            .add_document_bytes(
+                bytes=b"%PDF-1.4", format=DocumentFormatEnum.PDF, citations_enabled=False
+            )
+            .build()
+        )
+        document = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.DOCUMENT]
+        assert ConverseAPIFields.CITATIONS not in document
+
+    def test_local_document_forwards_citations(self):
+        """add_local_document forwards citations_enabled / context to add_document_bytes."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "report.pdf"
+            path.write_bytes(b"%PDF-1.4 test")
+            message = (
+                ConverseMessageBuilder(role=RolesEnum.USER)
+                .add_local_document(
+                    path_to_local_file=str(path),
+                    format=DocumentFormatEnum.PDF,
+                    citations_enabled=True,
+                    context="local ctx",
+                )
+                .build()
+            )
+            document = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.DOCUMENT]
+            assert document[ConverseAPIFields.CITATIONS] == {ConverseAPIFields.ENABLED: True}
+            assert document[ConverseAPIFields.CONTEXT] == "local ctx"


### PR DESCRIPTION
Closes #40.

## Problem

Document citations were unsupported on both ends: the document builders accepted only format/name/bytes — no way to request `citations` or `context` — and there was no typed parsing of the `citationsContent` the model returns. Citations were reachable only via the raw response dict.

## What this adds

- **Builder**: `add_document_bytes(..., citations_enabled=False, context=None)` adds `citations: {"enabled": True}` and/or a `context` string to the `DocumentBlock`; `add_local_document` forwards both. **Default off** → existing behavior unchanged (no `citations`/`context` keys added).
- **`BedrockResponse.get_citations()`** → `List[Citation]`, flattening citations from every `citationsContent` block via the #41 `get_content_blocks_by_type(CITATIONS_CONTENT)` iterator.
- **`StreamingResponse.get_citations()`** → citations accumulated from streamed `citation` deltas (the streaming handler now surfaces the full citation object, keeping the pre-existing `citation_title` shortcut).
- **`Citation`** — a frozen dataclass (exported from the package): `title`, `source`, `source_content` (referenced spans), `location` (union dict). Plus the citation field constants.

## Design notes

- Shapes from the AWS Bedrock Runtime `DocumentBlock` (`citations`: `CitationsConfig{enabled}`, `context`), `CitationsContentBlock` (`citations[]` + `content[]`), and `Citation` (`title`/`source`/`sourceContent[]`/`location`), consulted via the AWS docs MCP server.
- `citations_enabled`/`context` are keyword args on the existing document builders (not a separate method) so they stay attached to the right document and remain backward compatible. The structured-`content` / `s3Location` `DocumentSource` members overlap with #34 (S3 sources) and are deferred there. Rationale + alternatives in the spec decision log (DL-001/002).

## Proof

- Unit tests: `test_citation.py` (parse), `test_message_builder.py::TestDocumentCitations` (request JSON: citations/context/default-off/forwarding), `test_bedrock_response.py::TestBedrockResponseCitations` (non-streaming parse + multi-block flatten + empty cases) and `::TestStreamingResponseCitations` (streaming accumulation), plus the package export. One pre-existing `add_local_document` test was tightened to expect the two new defaulted kwargs (backward-compatible, not weakened).
- Full unit suite: **2761 passed, 7 skipped, 0 failed**. New `citation.py` at **100%** coverage.
- `ruff format --check` ✓, `ruff check` ✓, `mypy --exclude="_version" src/` ✓.
- Independently adversarially verified: 9 mutation-based claims, **0 refuted**; the one non-blocking cleanliness note (a redundant handler statement) was then removed.

No breaking changes.