### PR TITLE
Support S3 sources (s3Location + bucketOwner) for image/document/video blocks (#34)

### DIFF
--- a/docs/forLLMConsumption.md
+++ b/docs/forLLMConsumption.md
@@ -208,6 +208,34 @@ message = create_user_message()\
     .build()
 ```
 
+#### S3-sourced Media (image / document / video)
+
+Attach media stored in Amazon S3 instead of inlining bytes — useful for large files
+that would exceed the inlined-bytes request-size limits. `format` is **required** (no
+bytes are read locally to sniff it), and no local size/format check is performed.
+
+```python
+def add_image_s3(self, uri: str, format: ImageFormatEnum, bucket_owner: Optional[str] = None)
+def add_document_s3(self, uri: str, format: DocumentFormatEnum, name=None,
+                    bucket_owner=None, citations_enabled=False, context=None)
+def add_video_s3(self, uri: str, format: VideoFormatEnum, bucket_owner: Optional[str] = None)
+```
+
+```python
+from bestehorn_llmmanager.message_builder_enums import ImageFormatEnum
+
+message = create_user_message()\
+    .add_text("Describe this image.")\
+    .add_image_s3(uri="s3://my-bucket/photo.png", format=ImageFormatEnum.PNG)\
+    .build()
+# Produces source: {"s3Location": {"uri": "s3://my-bucket/photo.png"}}
+```
+
+- `uri` must start with `s3://`; `bucket_owner` (optional) is the **12-digit AWS account
+  ID** of the bucket owner — required when the bucket belongs to another account.
+- **IAM**: the model's execution role needs `s3:GetObject` on the referenced object (and
+  `s3:GetObject` is evaluated against `bucket_owner` for cross-account buckets).
+
 #### Tool Use (Function Calling) Round-Trip
 
 ```python

--- a/src/bestehorn_llmmanager/message_builder.py
+++ b/src/bestehorn_llmmanager/message_builder.py
@@ -591,6 +591,183 @@ class ConverseMessageBuilder:
         # Use the existing add_video_bytes method
         return self.add_video_bytes(bytes=video_bytes, format=format, filename=file_path.name)
 
+    def _build_s3_source(
+        self, uri: str, bucket_owner: Optional[str], content_type: str
+    ) -> Dict[str, Any]:
+        """
+        Validate an S3 URI / bucket owner and build the ``source.s3Location`` payload.
+
+        Args:
+            uri: An object URI starting with ``s3://``.
+            bucket_owner: Optional 12-digit AWS account ID of the bucket owner (required
+                when the bucket belongs to another account; the caller's role needs
+                ``s3:GetObject`` on the object).
+            content_type: The media type, for error messages.
+
+        Returns:
+            A ``{"s3Location": {"uri": ..., "bucketOwner"?: ...}}`` source dict.
+
+        Raises:
+            RequestValidationError: If ``uri`` is empty / not an ``s3://`` URI, or
+                ``bucket_owner`` is not a 12-digit account ID.
+        """
+        if not uri or not uri.startswith("s3://"):
+            raise RequestValidationError(
+                MessageBuilderErrorMessages.INVALID_CONTENT_TYPE.format(
+                    content_type=(f"{content_type} S3 URI (must start with 's3://', got {uri!r})")
+                )
+            )
+        if bucket_owner is not None and not (len(bucket_owner) == 12 and bucket_owner.isdigit()):
+            raise RequestValidationError(
+                MessageBuilderErrorMessages.INVALID_CONTENT_TYPE.format(
+                    content_type=(
+                        f"bucket_owner (must be a 12-digit AWS account ID, got {bucket_owner!r})"
+                    )
+                )
+            )
+
+        s3_location: Dict[str, Any] = {ConverseAPIFields.URI: uri}
+        if bucket_owner is not None:
+            s3_location[ConverseAPIFields.BUCKET_OWNER] = bucket_owner
+        return {ConverseAPIFields.S3_LOCATION: s3_location}
+
+    def add_image_s3(
+        self,
+        uri: str,
+        format: ImageFormatEnum,
+        bucket_owner: Optional[str] = None,
+    ) -> "ConverseMessageBuilder":
+        """
+        Add an image content block sourced from Amazon S3.
+
+        Unlike :meth:`add_image_bytes`, no bytes are read or size-checked locally; the
+        model fetches the object from S3 at request time, so ``format`` is required (it
+        cannot be auto-detected from content).
+
+        Args:
+            uri: An ``s3://`` object URI for the image.
+            format: The image format (required for S3 sources).
+            bucket_owner: Optional 12-digit AWS account ID, required when the bucket
+                belongs to another account. The model's execution role needs
+                ``s3:GetObject`` on the object.
+
+        Returns:
+            Self for method chaining.
+
+        Raises:
+            RequestValidationError: If the URI or bucket owner is invalid.
+        """
+        self._validate_content_block_limit()
+
+        image_block = {
+            ConverseAPIFields.IMAGE: {
+                ConverseAPIFields.FORMAT: format.value,
+                ConverseAPIFields.SOURCE: self._build_s3_source(
+                    uri=uri, bucket_owner=bucket_owner, content_type="image"
+                ),
+            }
+        }
+        self._content_blocks.append(image_block)
+        self._cacheable_blocks.append(False)
+        self._logger.debug(
+            MessageBuilderLogMessages.CONTENT_BLOCK_ADDED.format(
+                content_type=f"image-s3 ({format.value})", size=len(uri)
+            )
+        )
+        return self
+
+    def add_document_s3(
+        self,
+        uri: str,
+        format: DocumentFormatEnum,
+        name: Optional[str] = None,
+        bucket_owner: Optional[str] = None,
+        citations_enabled: bool = False,
+        context: Optional[str] = None,
+    ) -> "ConverseMessageBuilder":
+        """
+        Add a document content block sourced from Amazon S3.
+
+        Args:
+            uri: An ``s3://`` object URI for the document.
+            format: The document format (required for S3 sources).
+            name: Optional document name for the API.
+            bucket_owner: Optional 12-digit AWS account ID for a cross-account bucket
+                (the model's role needs ``s3:GetObject``).
+            citations_enabled: When True, enables document citations (see
+                :meth:`add_document_bytes`).
+            context: Optional citation context string.
+
+        Returns:
+            Self for method chaining.
+
+        Raises:
+            RequestValidationError: If the URI or bucket owner is invalid.
+        """
+        self._validate_content_block_limit()
+
+        document_inner: Dict[str, Any] = {
+            ConverseAPIFields.FORMAT: format.value,
+            ConverseAPIFields.SOURCE: self._build_s3_source(
+                uri=uri, bucket_owner=bucket_owner, content_type="document"
+            ),
+        }
+        if name:
+            document_inner[ConverseAPIFields.NAME] = name
+        if citations_enabled:
+            document_inner[ConverseAPIFields.CITATIONS] = {ConverseAPIFields.ENABLED: True}
+        if context is not None:
+            document_inner[ConverseAPIFields.CONTEXT] = context
+
+        self._content_blocks.append({ConverseAPIFields.DOCUMENT: document_inner})
+        self._cacheable_blocks.append(False)
+        self._logger.debug(
+            MessageBuilderLogMessages.CONTENT_BLOCK_ADDED.format(
+                content_type=f"document-s3 ({format.value})", size=len(uri)
+            )
+        )
+        return self
+
+    def add_video_s3(
+        self,
+        uri: str,
+        format: VideoFormatEnum,
+        bucket_owner: Optional[str] = None,
+    ) -> "ConverseMessageBuilder":
+        """
+        Add a video content block sourced from Amazon S3.
+
+        Args:
+            uri: An ``s3://`` object URI for the video.
+            format: The video format (required for S3 sources).
+            bucket_owner: Optional 12-digit AWS account ID for a cross-account bucket
+                (the model's role needs ``s3:GetObject``).
+
+        Returns:
+            Self for method chaining.
+
+        Raises:
+            RequestValidationError: If the URI or bucket owner is invalid.
+        """
+        self._validate_content_block_limit()
+
+        video_block = {
+            ConverseAPIFields.VIDEO: {
+                ConverseAPIFields.FORMAT: format.value,
+                ConverseAPIFields.SOURCE: self._build_s3_source(
+                    uri=uri, bucket_owner=bucket_owner, content_type="video"
+                ),
+            }
+        }
+        self._content_blocks.append(video_block)
+        self._cacheable_blocks.append(False)
+        self._logger.debug(
+            MessageBuilderLogMessages.CONTENT_BLOCK_ADDED.format(
+                content_type=f"video-s3 ({format.value})", size=len(uri)
+            )
+        )
+        return self
+
     def add_cache_point(self, cache_type: str = "default") -> "ConverseMessageBuilder":
         """
         Add an explicit cache point at the current position.

--- a/test/bestehorn_llmmanager/test_message_builder.py
+++ b/test/bestehorn_llmmanager/test_message_builder.py
@@ -1289,3 +1289,101 @@ class TestDocumentCitations:
             document = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.DOCUMENT]
             assert document[ConverseAPIFields.CITATIONS] == {ConverseAPIFields.ENABLED: True}
             assert document[ConverseAPIFields.CONTEXT] == "local ctx"
+
+
+class TestS3MediaSources:
+    """S3-sourced image/document/video builder methods (issue #34)."""
+
+    def test_add_image_s3_builds_block(self):
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.USER)
+            .add_image_s3(uri="s3://my-bucket/photo.png", format=ImageFormatEnum.PNG)
+            .build()
+        )
+        image = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.IMAGE]
+        assert image[ConverseAPIFields.FORMAT] == "png"
+        s3 = image[ConverseAPIFields.SOURCE][ConverseAPIFields.S3_LOCATION]
+        assert s3[ConverseAPIFields.URI] == "s3://my-bucket/photo.png"
+        assert ConverseAPIFields.BUCKET_OWNER not in s3
+        # No bytes source for an S3-sourced block.
+        assert ConverseAPIFields.BYTES not in image[ConverseAPIFields.SOURCE]
+
+    def test_add_image_s3_with_bucket_owner(self):
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.USER)
+            .add_image_s3(
+                uri="s3://other/photo.jpg",
+                format=ImageFormatEnum.JPEG,
+                bucket_owner="123456789012",
+            )
+            .build()
+        )
+        s3 = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.IMAGE][
+            ConverseAPIFields.SOURCE
+        ][ConverseAPIFields.S3_LOCATION]
+        assert s3[ConverseAPIFields.BUCKET_OWNER] == "123456789012"
+
+    def test_add_document_s3_builds_block(self):
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.USER)
+            .add_document_s3(
+                uri="s3://my-bucket/report.pdf",
+                format=DocumentFormatEnum.PDF,
+                name="Report",
+            )
+            .build()
+        )
+        document = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.DOCUMENT]
+        assert document[ConverseAPIFields.FORMAT] == "pdf"
+        assert document[ConverseAPIFields.NAME] == "Report"
+        s3 = document[ConverseAPIFields.SOURCE][ConverseAPIFields.S3_LOCATION]
+        assert s3[ConverseAPIFields.URI] == "s3://my-bucket/report.pdf"
+
+    def test_add_document_s3_with_citations(self):
+        """S3 documents also support citations/context (consistency with bytes path)."""
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.USER)
+            .add_document_s3(
+                uri="s3://b/r.pdf",
+                format=DocumentFormatEnum.PDF,
+                citations_enabled=True,
+                context="ctx",
+            )
+            .build()
+        )
+        document = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.DOCUMENT]
+        assert document[ConverseAPIFields.CITATIONS] == {ConverseAPIFields.ENABLED: True}
+        assert document[ConverseAPIFields.CONTEXT] == "ctx"
+
+    def test_add_video_s3_builds_block(self):
+        message = (
+            ConverseMessageBuilder(role=RolesEnum.USER)
+            .add_video_s3(uri="s3://my-bucket/clip.mp4", format=VideoFormatEnum.MP4)
+            .build()
+        )
+        video = message[ConverseAPIFields.CONTENT][0][ConverseAPIFields.VIDEO]
+        assert video[ConverseAPIFields.FORMAT] == "mp4"
+        s3 = video[ConverseAPIFields.SOURCE][ConverseAPIFields.S3_LOCATION]
+        assert s3[ConverseAPIFields.URI] == "s3://my-bucket/clip.mp4"
+
+    def test_s3_uri_must_start_with_scheme(self):
+        with pytest.raises(RequestValidationError):
+            ConverseMessageBuilder(role=RolesEnum.USER).add_image_s3(
+                uri="https://not-s3/photo.png", format=ImageFormatEnum.PNG
+            )
+
+    def test_s3_uri_empty_rejected(self):
+        with pytest.raises(RequestValidationError):
+            ConverseMessageBuilder(role=RolesEnum.USER).add_image_s3(
+                uri="", format=ImageFormatEnum.PNG
+            )
+
+    def test_s3_bucket_owner_must_be_12_digits(self):
+        with pytest.raises(RequestValidationError):
+            ConverseMessageBuilder(role=RolesEnum.USER).add_image_s3(
+                uri="s3://b/p.png", format=ImageFormatEnum.PNG, bucket_owner="abc"
+            )
+
+    def test_add_image_s3_returns_self(self):
+        builder = ConverseMessageBuilder(role=RolesEnum.USER)
+        assert builder.add_image_s3(uri="s3://b/p.png", format=ImageFormatEnum.PNG) is builder


### PR DESCRIPTION
Closes #34.

## Problem

All media content blocks (image, document, video) were bytes-only. The Converse API also accepts an Amazon **S3 source** (`s3Location` with `uri` + optional `bucketOwner`), which matters for large files that would otherwise blow the inlined-bytes request-size limits and avoids round-tripping bytes through the client. The `s3Location` constant existed but was never used.

## What this adds

Three S3-source builder methods:

```python
def add_image_s3(self, uri, format: ImageFormatEnum, bucket_owner=None)
def add_document_s3(self, uri, format: DocumentFormatEnum, name=None,
                    bucket_owner=None, citations_enabled=False, context=None)
def add_video_s3(self, uri, format: VideoFormatEnum, bucket_owner=None)
```

Each produces `{<media>: {format, source: {s3Location: {uri[, bucketOwner]}}}}`. A shared `_build_s3_source` helper validates:
- `uri` must start with `s3://` (matches the `S3Location.uri` contract);
- `bucket_owner` (optional) must be a **12-digit** AWS account ID (`S3Location.bucketOwner`).

`format` is a required enum (there are no bytes to sniff), and **no local file read or size check** is performed for S3 sources. Document S3 sources also accept `citations_enabled`/`context` for parity with the bytes path (#40).

## Design notes

- Separate `_s3` methods (not a `source_type` kwarg on the bytes methods): the bytes path auto-detects format and size-checks, which is meaningless for an S3 URI — separate methods keep each path's validation honest. Rationale + alternatives in the spec decision log (DL-001).
- Shapes from the AWS Bedrock Runtime `S3Location` and `DocumentSource`/`ImageSource`/`VideoSource` (consulted via the AWS docs MCP server).

## Proof

- Unit tests (`test_message_builder.py::TestS3MediaSources`): exact request JSON for image/document/video (incl. **no `bytes` key**), `bucketOwner` included only when given, `s3://`-prefix + empty-URI rejection, 12-digit `bucket_owner` rejection, document S3 citations/context. Verified the S3 methods perform **zero filesystem access**.
- Full unit suite: **2770 passed, 7 skipped, 0 failed**. New S3 code fully covered.
- `ruff format --check` ✓, `ruff check` ✓, `mypy --exclude="_version" src/` ✓.
- Independently adversarially verified: 12 claims, **0 refuted** (5 mutations killed by specific assertions).

## Deferred

The live-bucket `aws_integration` test (checklist item) is **deferred** — it needs a real S3 bucket + Bedrock credentials not available in this environment. The build-side request JSON (the only non-AWS-dependent part) is fully covered by the unit tests above, and the IAM `s3:GetObject` / `bucketOwner` semantics are documented. A future credentialed run can add the live test.

No breaking changes.