### PR TITLE
Support structured output (outputConfig.textFormat json_schema) (#35)

### DIFF
--- a/docs/forLLMConsumption.md
+++ b/docs/forLLMConsumption.md
@@ -377,6 +377,38 @@ Response/StreamingResponse accessor:
 def get_citations(self) -> List[Citation]   # typed (title, source, source_content, location)
 ```
 
+#### Structured Output (JSON schema)
+
+Force the model to return schema-valid JSON natively via `output_config` on
+`converse()` / `converse_stream()` (the Converse `outputConfig.textFormat`
+`json_schema` feature). Build the config with the helper, and read the parsed object
+back with `get_structured_output()`:
+
+```python
+from bestehorn_llmmanager import build_json_schema_output_config
+
+schema = {
+    "type": "object",
+    "properties": {"sentiment": {"type": "string"}, "score": {"type": "number"}},
+    "required": ["sentiment", "score"],
+}
+output_config = build_json_schema_output_config(schema=schema)
+# -> {"textFormat": {"type": "json_schema", "structure": schema}}
+
+response = manager.converse(
+    messages=[{"role": "user", "content": [{"text": "Classify: 'I love it!'"}]}],
+    output_config=output_config,
+)
+data = response.get_structured_output()   # dict/list, or None if content isn't JSON
+```
+
+**Structured output vs. response-validation-retry:** structured output constrains
+generation at the API level (one call, guaranteed-shape JSON) and is preferred when the
+model/region supports it. The existing `response_validation_config` retry approach
+re-calls the model when a validator rejects output — a more general but more expensive
+fallback for models without structured-output support or for semantic (not just
+schema) validation.
+
 #### Building Messages
 
 ```python

--- a/src/bestehorn_llmmanager/__init__.py
+++ b/src/bestehorn_llmmanager/__init__.py
@@ -54,6 +54,9 @@ from .bedrock.models.model_specific_structures import ModelSpecificConfig
 # Reasoning / extended-thinking typed content
 from .bedrock.models.reasoning_content import ReasoningContent
 
+# Structured output (outputConfig.textFormat json_schema) helper
+from .bedrock.models.structured_output import build_json_schema_output_config
+
 # Tool use (function calling) typed request object
 from .bedrock.models.tool_use import ToolUse
 from .bedrock.tracking.parameter_compatibility_tracker import ParameterCompatibilityTracker
@@ -121,6 +124,8 @@ __all__ = [
     "ReasoningContent",
     # Document citations
     "Citation",
+    # Structured output
+    "build_json_schema_output_config",
     # Region utilities
     "BedrockRegionDiscovery",
     "get_all_regions",

--- a/src/bestehorn_llmmanager/bedrock/models/bedrock_response.py
+++ b/src/bestehorn_llmmanager/bedrock/models/bedrock_response.py
@@ -256,6 +256,31 @@ class BedrockResponse:
         text_parts = self.get_text_blocks()
         return "\n".join(text_parts) if text_parts else None
 
+    def get_structured_output(self) -> Optional[Any]:
+        """
+        Parse the response text content as a structured JSON object or array.
+
+        When a request is made with structured output (``output_config`` /
+        ``outputConfig.textFormat`` with ``type="json_schema"``), the model returns
+        schema-valid JSON as its text content. This parses :meth:`get_content` as JSON
+        and returns the resulting object/array.
+
+        Returns:
+            The parsed JSON value when the text content is a JSON object or array;
+            ``None`` if there is no content, the content is not valid JSON, or it parses
+            to a non-structured scalar (string/number/bool/null).
+        """
+        content = self.get_content()
+        if not content:
+            return None
+        try:
+            parsed = json.loads(content)
+        except (ValueError, TypeError):
+            return None
+        if isinstance(parsed, (dict, list)):
+            return parsed
+        return None
+
     def get_usage(self) -> Optional[Dict[str, int]]:
         """
         Get token usage information from the response.

--- a/src/bestehorn_llmmanager/bedrock/models/llm_manager_constants.py
+++ b/src/bestehorn_llmmanager/bedrock/models/llm_manager_constants.py
@@ -23,6 +23,13 @@ class ConverseAPIFields:
     TOOL_CONFIG: Final[str] = "toolConfig"
     REQUEST_METADATA: Final[str] = "requestMetadata"
     PROMPT_VARIABLES: Final[str] = "promptVariables"
+    OUTPUT_CONFIG: Final[str] = "outputConfig"
+
+    # Structured output (outputConfig.textFormat) fields
+    TEXT_FORMAT: Final[str] = "textFormat"
+    OUTPUT_FORMAT_TYPE: Final[str] = "type"
+    OUTPUT_FORMAT_STRUCTURE: Final[str] = "structure"
+    OUTPUT_FORMAT_JSON_SCHEMA: Final[str] = "json_schema"
 
     # Message fields
     ROLE: Final[str] = "role"

--- a/src/bestehorn_llmmanager/bedrock/models/structured_output.py
+++ b/src/bestehorn_llmmanager/bedrock/models/structured_output.py
@@ -1,0 +1,45 @@
+"""
+Helpers for the Bedrock Converse structured-output feature (issue #35).
+
+Provides :func:`build_json_schema_output_config`, which wraps a JSON Schema into the
+Converse ``outputConfig`` envelope (``{"textFormat": {"type": "json_schema",
+"structure": <schema>}}``) accepted by :meth:`LLMManager.converse`'s ``output_config``
+parameter. This is the API-native way to force schema-valid JSON output, distinct from
+the library's response-validation-retry approach (which re-calls the model instead of
+constraining generation).
+
+Reference: Converse request ``outputConfig`` / ``OutputConfig`` / text format:
+https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
+"""
+
+from typing import Any, Dict
+
+from ..exceptions.llm_manager_exceptions import RequestValidationError
+from .llm_manager_constants import ConverseAPIFields
+
+
+def build_json_schema_output_config(schema: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Build an ``outputConfig`` for JSON-schema-constrained structured output.
+
+    Args:
+        schema: A JSON Schema object (a dict) describing the required output shape.
+
+    Returns:
+        An ``outputConfig`` dict ready to pass to ``converse(output_config=...)``::
+
+            {"textFormat": {"type": "json_schema", "structure": <schema>}}
+
+    Raises:
+        RequestValidationError: If ``schema`` is not a non-empty dict.
+    """
+    if not isinstance(schema, dict) or not schema:
+        raise RequestValidationError(
+            f"output_config schema must be a non-empty JSON Schema dict, got {type(schema).__name__}"
+        )
+    return {
+        ConverseAPIFields.TEXT_FORMAT: {
+            ConverseAPIFields.OUTPUT_FORMAT_TYPE: ConverseAPIFields.OUTPUT_FORMAT_JSON_SCHEMA,
+            ConverseAPIFields.OUTPUT_FORMAT_STRUCTURE: schema,
+        }
+    }

--- a/src/bestehorn_llmmanager/llm_manager.py
+++ b/src/bestehorn_llmmanager/llm_manager.py
@@ -628,6 +628,7 @@ class LLMManager:
         request_metadata: Optional[Dict[str, Any]] = None,
         prompt_variables: Optional[Dict[str, Any]] = None,
         response_validation_config: Optional[ResponseValidationConfig] = None,
+        output_config: Optional[Dict[str, Any]] = None,
     ) -> BedrockResponse:
         """
         Send a conversation request to available models with retry logic.
@@ -645,6 +646,9 @@ class LLMManager:
             request_metadata: Metadata for the request
             prompt_variables: Variables for prompt templates
             response_validation_config: Configuration for response validation and retry
+            output_config: Structured-output config (outputConfig.textFormat) to constrain
+                the model's output to a JSON schema; build one with
+                ``bedrock.models.structured_output.build_json_schema_output_config``
 
         Returns:
             BedrockResponse with the conversation result
@@ -678,6 +682,7 @@ class LLMManager:
             tool_config=tool_config,
             request_metadata=request_metadata,
             prompt_variables=prompt_variables,
+            output_config=output_config,
         )
 
         # Generate retry targets
@@ -796,6 +801,7 @@ class LLMManager:
         tool_config: Optional[Dict[str, Any]] = None,
         request_metadata: Optional[Dict[str, Any]] = None,
         prompt_variables: Optional[Dict[str, Any]] = None,
+        output_config: Optional[Dict[str, Any]] = None,
     ) -> StreamingResponse:
         """
         Send a streaming conversation request to available models with retry logic and recovery.
@@ -816,6 +822,8 @@ class LLMManager:
             tool_config: Tool use configuration
             request_metadata: Metadata for the request
             prompt_variables: Variables for prompt templates
+            output_config: Structured-output config (outputConfig.textFormat) to constrain
+                the model's output to a JSON schema
 
         Returns:
             StreamingResponse with the streaming conversation result
@@ -849,6 +857,7 @@ class LLMManager:
             tool_config=tool_config,
             request_metadata=request_metadata,
             prompt_variables=prompt_variables,
+            output_config=output_config,
         )
 
         # Generate retry targets using the regular retry manager
@@ -1038,6 +1047,7 @@ class LLMManager:
         tool_config: Optional[Dict[str, Any]] = None,
         request_metadata: Optional[Dict[str, Any]] = None,
         prompt_variables: Optional[Dict[str, Any]] = None,
+        output_config: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Build the request arguments for the Converse API.
@@ -1053,6 +1063,7 @@ class LLMManager:
             tool_config: Tool configuration
             request_metadata: Request metadata
             prompt_variables: Prompt variables
+            output_config: Structured-output configuration (outputConfig.textFormat)
 
         Returns:
             Dictionary of request arguments for the Converse API
@@ -1124,6 +1135,9 @@ class LLMManager:
 
         if prompt_variables:
             request_args[ConverseAPIFields.PROMPT_VARIABLES] = prompt_variables
+
+        if output_config:
+            request_args[ConverseAPIFields.OUTPUT_CONFIG] = output_config
 
         return request_args
 

--- a/test/bestehorn_llmmanager/bedrock/models/test_bedrock_response.py
+++ b/test/bestehorn_llmmanager/bedrock/models/test_bedrock_response.py
@@ -591,6 +591,43 @@ class TestBedrockResponse:
         assert "FAILED" in repr_str
 
 
+class TestBedrockResponseStructuredOutput:
+    """Tests for get_structured_output (issue #35)."""
+
+    def test_parses_json_object(self):
+        response_data = {
+            "output": {"message": {"content": [{"text": '{"name": "Ada", "age": 36}'}]}}
+        }
+        response = BedrockResponse(success=True, response_data=response_data)
+        assert response.get_structured_output() == {"name": "Ada", "age": 36}
+
+    def test_parses_json_across_multiple_text_blocks(self):
+        """Text blocks are joined before parsing (get_content semantics)."""
+        response_data = {"output": {"message": {"content": [{"text": '{"a":'}, {"text": " 1}"}]}}}
+        response = BedrockResponse(success=True, response_data=response_data)
+        # get_content joins with newline; JSON tolerates the whitespace.
+        assert response.get_structured_output() == {"a": 1}
+
+    def test_returns_none_for_non_json_content(self):
+        response_data = {"output": {"message": {"content": [{"text": "not json"}]}}}
+        response = BedrockResponse(success=True, response_data=response_data)
+        assert response.get_structured_output() is None
+
+    def test_returns_none_when_no_content(self):
+        assert BedrockResponse(success=True, response_data=None).get_structured_output() is None
+
+    def test_returns_none_for_json_scalar(self):
+        """A bare JSON scalar is not a structured object/array; return None."""
+        response_data = {"output": {"message": {"content": [{"text": "42"}]}}}
+        response = BedrockResponse(success=True, response_data=response_data)
+        assert response.get_structured_output() is None
+
+    def test_parses_json_array(self):
+        response_data = {"output": {"message": {"content": [{"text": "[1, 2, 3]"}]}}}
+        response = BedrockResponse(success=True, response_data=response_data)
+        assert response.get_structured_output() == [1, 2, 3]
+
+
 class TestBedrockResponseCitations:
     """Tests for the document-citation response accessor (issue #40, non-streaming)."""
 

--- a/test/bestehorn_llmmanager/bedrock/models/test_structured_output.py
+++ b/test/bestehorn_llmmanager/bedrock/models/test_structured_output.py
@@ -1,0 +1,34 @@
+"""
+Tests for the structured-output helper (issue #35).
+"""
+
+import pytest
+
+from bestehorn_llmmanager.bedrock.exceptions.llm_manager_exceptions import RequestValidationError
+from bestehorn_llmmanager.bedrock.models.structured_output import build_json_schema_output_config
+
+
+class TestBuildJsonSchemaOutputConfig:
+    """build_json_schema_output_config wraps a JSON Schema into outputConfig."""
+
+    def test_wraps_schema(self):
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        }
+        config = build_json_schema_output_config(schema=schema)
+        assert config == {
+            "textFormat": {
+                "type": "json_schema",
+                "structure": schema,
+            }
+        }
+
+    def test_empty_schema_rejected(self):
+        with pytest.raises(RequestValidationError):
+            build_json_schema_output_config(schema={})
+
+    def test_non_dict_schema_rejected(self):
+        with pytest.raises(RequestValidationError):
+            build_json_schema_output_config(schema="not-a-dict")  # type: ignore[arg-type]

--- a/test/bestehorn_llmmanager/test_LLMManager.py
+++ b/test/bestehorn_llmmanager/test_LLMManager.py
@@ -300,6 +300,48 @@ class TestLLMManager:
         for field in expected_fields:
             assert field in request_args
 
+    def test_build_converse_request_with_output_config(self, basic_llm_manager):
+        """output_config is forwarded to the request as outputConfig (issue #35)."""
+        messages = [{"role": "user", "content": [{"text": "Hello"}]}]
+        output_config = {
+            "textFormat": {
+                "type": "json_schema",
+                "structure": {"type": "object", "properties": {"x": {"type": "number"}}},
+            }
+        }
+
+        request_args = basic_llm_manager._build_converse_request(
+            messages=messages, output_config=output_config
+        )
+
+        assert request_args[ConverseAPIFields.OUTPUT_CONFIG] == output_config
+
+    def test_build_converse_request_without_output_config_omits_field(self, basic_llm_manager):
+        """outputConfig is absent when output_config is not provided (backward compatible)."""
+        messages = [{"role": "user", "content": [{"text": "Hello"}]}]
+        request_args = basic_llm_manager._build_converse_request(messages=messages)
+        assert ConverseAPIFields.OUTPUT_CONFIG not in request_args
+
+    def test_converse_forwards_output_config_to_api(self, basic_llm_manager):
+        """converse(output_config=...) reaches the boto3 client call as outputConfig."""
+        output_config = {"textFormat": {"type": "json_schema", "structure": {"type": "object"}}}
+        mock_client = Mock()
+        mock_client.converse.return_value = {
+            "output": {"message": {"content": [{"text": "{}"}]}},
+            "stopReason": "end_turn",
+        }
+        with patch.object(
+            basic_llm_manager._auth_manager, "get_bedrock_client", return_value=mock_client
+        ):
+            basic_llm_manager.converse(
+                messages=[{"role": "user", "content": [{"text": "Hi"}]}],
+                output_config=output_config,
+            )
+        assert mock_client.converse.called
+        assert mock_client.converse.call_args.kwargs[ConverseAPIFields.OUTPUT_CONFIG] == (
+            output_config
+        )
+
     def test_get_model_access_info_success(self, basic_llm_manager):
         """Test successful retrieval of model access information."""
         result = basic_llm_manager.get_model_access_info("Claude Haiku 4 5 20251001", "us-east-1")

--- a/test/bestehorn_llmmanager/test_init.py
+++ b/test/bestehorn_llmmanager/test_init.py
@@ -43,6 +43,9 @@ class TestPackageInit:
         # Test document-citation type
         assert hasattr(bestehorn_llmmanager, "Citation")
 
+        # Test structured-output helper
+        assert hasattr(bestehorn_llmmanager, "build_json_schema_output_config")
+
     def test_version_handling_with_version_import_success(self):
         """Test version handling when _version import succeeds."""
         # This will use the actual _version.py file which should exist
@@ -113,6 +116,7 @@ class TestPackageInit:
             "ToolUse",
             "ReasoningContent",
             "Citation",
+            "build_json_schema_output_config",
         ]
 
         assert hasattr(bestehorn_llmmanager, "__all__")


### PR DESCRIPTION
Closes #35.

## Problem

The Converse **structured output** feature (`outputConfig.textFormat` with `type: json_schema`) — the API-native way to force schema-valid JSON — was unsupported. `converse()` had an explicit signature with no `outputConfig` and no `**kwargs`, so there was no path to set it; the library only offered the weaker/costlier response-validation-retry substitute.

## What this adds

- **`output_config` parameter** on `converse()` and `converse_stream()`, threaded through `_build_converse_request` to the boto3 `outputConfig` request field. Omitted when not provided, so existing calls are unchanged.
- **`build_json_schema_output_config(schema)`** helper (new `structured_output.py`, exported from the package) wrapping a JSON Schema dict into `{"textFormat": {"type": "json_schema", "structure": schema}}`; rejects empty/non-dict schemas.
- **`BedrockResponse.get_structured_output()`** parses the text content as JSON and returns the object/array — `None` for empty / non-JSON / bare-scalar content (consistent with the other None-on-failure accessors).
- The `outputConfig`/`textFormat` field constants.

## Design notes

- `output_config` is a passthrough dict plus a schema-wrapping helper (rather than a locked-down typed dataclass): this satisfies both "first-class way to pass `outputConfig`" and "accept a Python dict schema and serialize it" without freezing the surface before the feature is broadly model-supported. Parsing is opt-in via `get_structured_output()`. Rationale + alternatives in the spec decision log (DL-001/002).
- The `outputConfig.textFormat` `{type, structure}` shape was taken from the AWS Converse request reference (consulted via the AWS docs MCP server).

## Proof

- Unit tests: `test_structured_output.py` (envelope build + empty/non-dict rejection), `test_bedrock_response.py::TestBedrockResponseStructuredOutput` (object/array parse, non-JSON/scalar/empty → None), and `test_LLMManager.py` — including a **mocked `converse(output_config=...)` asserting `outputConfig` reaches the boto3 `converse` call**, plus the default-omitted backward-compat case. Package export asserted in `test_init.py`.
- Full unit suite: **2782 passed, 7 skipped, 0 failed**. New `structured_output.py` at **100%** coverage.
- `ruff format --check` ✓, `ruff check` ✓, `mypy --exclude="_version" src/` ✓.
- Independently adversarially verified: 10 mutation-based claims, **0 refuted**.

Documents structured output vs. the existing response-validation-retry approach (when to use which). No breaking changes.