### PR TITLE
Support performanceConfig + serviceTier and a forward-compatible request passthrough (#36)

### DIFF
--- a/docs/forLLMConsumption.md
+++ b/docs/forLLMConsumption.md
@@ -693,9 +693,20 @@ def converse(
     tool_config: Optional[Dict[str, Any]] = None,         # Optional: Tool use configuration
     request_metadata: Optional[Dict[str, Any]] = None,    # Optional: Request metadata
     prompt_variables: Optional[Dict[str, Any]] = None,    # Optional: Prompt template variables
-    response_validation_config: Optional[ResponseValidationConfig] = None  # Optional: Response validation
+    response_validation_config: Optional[ResponseValidationConfig] = None,  # Optional: Response validation
+    output_config: Optional[Dict[str, Any]] = None,       # Optional: Structured output (#35)
+    performance_config: Optional[Dict[str, Any]] = None,  # Optional: {"latency": "standard"|"optimized"}
+    service_tier: Optional[Dict[str, Any]] = None,        # Optional: {"type": "priority"|"default"|"flex"|"reserved"}
+    extra_request_fields: Optional[Dict[str, Any]] = None  # Optional: forward-compatible passthrough (merged last)
 ) -> BedrockResponse
 ```
+
+`performance_config` and `service_tier` are echoed back via
+`response.get_performance_config()` / `response.get_service_tier()`.
+`extra_request_fields` is a forward-compatible escape hatch: any keys it contains are
+merged into the Converse request **last** (overriding first-class params on conflict),
+so a new top-level Converse parameter can be used before the library adds a named
+argument for it. (Both `converse()` and `converse_stream()` accept all four.)
 
 **converse_stream() - Streaming conversation requests**
 ```python

--- a/src/bestehorn_llmmanager/bedrock/models/bedrock_response.py
+++ b/src/bestehorn_llmmanager/bedrock/models/bedrock_response.py
@@ -435,6 +435,35 @@ class BedrockResponse:
         except (KeyError, TypeError, AttributeError):
             return None
 
+    def get_performance_config(self) -> Optional[Dict[str, Any]]:
+        """
+        Get the performance configuration echoed back in the response (issue #36).
+
+        Returns:
+            The ``performanceConfig`` dict (e.g. ``{"latency": "optimized"}``) if present,
+            None otherwise.
+        """
+        if not self.success or not self.response_data:
+            return None
+        try:
+            return self.response_data.get(ConverseAPIFields.PERFORMANCE_CONFIG)
+        except (KeyError, TypeError, AttributeError):
+            return None
+
+    def get_service_tier(self) -> Optional[Dict[str, Any]]:
+        """
+        Get the service tier echoed back in the response (issue #36).
+
+        Returns:
+            The ``serviceTier`` dict (e.g. ``{"type": "flex"}``) if present, None otherwise.
+        """
+        if not self.success or not self.response_data:
+            return None
+        try:
+            return self.response_data.get(ConverseAPIFields.SERVICE_TIER)
+        except (KeyError, TypeError, AttributeError):
+            return None
+
     def was_successful(self) -> bool:
         """
         Check if the request was successful.

--- a/src/bestehorn_llmmanager/bedrock/models/llm_manager_constants.py
+++ b/src/bestehorn_llmmanager/bedrock/models/llm_manager_constants.py
@@ -24,6 +24,8 @@ class ConverseAPIFields:
     REQUEST_METADATA: Final[str] = "requestMetadata"
     PROMPT_VARIABLES: Final[str] = "promptVariables"
     OUTPUT_CONFIG: Final[str] = "outputConfig"
+    PERFORMANCE_CONFIG: Final[str] = "performanceConfig"
+    SERVICE_TIER: Final[str] = "serviceTier"
 
     # Structured output (outputConfig.textFormat) fields
     TEXT_FORMAT: Final[str] = "textFormat"

--- a/src/bestehorn_llmmanager/llm_manager.py
+++ b/src/bestehorn_llmmanager/llm_manager.py
@@ -629,6 +629,9 @@ class LLMManager:
         prompt_variables: Optional[Dict[str, Any]] = None,
         response_validation_config: Optional[ResponseValidationConfig] = None,
         output_config: Optional[Dict[str, Any]] = None,
+        performance_config: Optional[Dict[str, Any]] = None,
+        service_tier: Optional[Dict[str, Any]] = None,
+        extra_request_fields: Optional[Dict[str, Any]] = None,
     ) -> BedrockResponse:
         """
         Send a conversation request to available models with retry logic.
@@ -683,6 +686,9 @@ class LLMManager:
             request_metadata=request_metadata,
             prompt_variables=prompt_variables,
             output_config=output_config,
+            performance_config=performance_config,
+            service_tier=service_tier,
+            extra_request_fields=extra_request_fields,
         )
 
         # Generate retry targets
@@ -802,6 +808,9 @@ class LLMManager:
         request_metadata: Optional[Dict[str, Any]] = None,
         prompt_variables: Optional[Dict[str, Any]] = None,
         output_config: Optional[Dict[str, Any]] = None,
+        performance_config: Optional[Dict[str, Any]] = None,
+        service_tier: Optional[Dict[str, Any]] = None,
+        extra_request_fields: Optional[Dict[str, Any]] = None,
     ) -> StreamingResponse:
         """
         Send a streaming conversation request to available models with retry logic and recovery.
@@ -858,6 +867,9 @@ class LLMManager:
             request_metadata=request_metadata,
             prompt_variables=prompt_variables,
             output_config=output_config,
+            performance_config=performance_config,
+            service_tier=service_tier,
+            extra_request_fields=extra_request_fields,
         )
 
         # Generate retry targets using the regular retry manager
@@ -1048,6 +1060,9 @@ class LLMManager:
         request_metadata: Optional[Dict[str, Any]] = None,
         prompt_variables: Optional[Dict[str, Any]] = None,
         output_config: Optional[Dict[str, Any]] = None,
+        performance_config: Optional[Dict[str, Any]] = None,
+        service_tier: Optional[Dict[str, Any]] = None,
+        extra_request_fields: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Build the request arguments for the Converse API.
@@ -1138,6 +1153,18 @@ class LLMManager:
 
         if output_config:
             request_args[ConverseAPIFields.OUTPUT_CONFIG] = output_config
+
+        if performance_config:
+            request_args[ConverseAPIFields.PERFORMANCE_CONFIG] = performance_config
+
+        if service_tier:
+            request_args[ConverseAPIFields.SERVICE_TIER] = service_tier
+
+        # Forward-compatible escape hatch: merge any caller-supplied top-level Converse
+        # fields LAST so future API parameters can be used without a library release
+        # (and so an explicit override wins over a first-class param on key conflict).
+        if extra_request_fields:
+            request_args.update(extra_request_fields)
 
         return request_args
 

--- a/test/bestehorn_llmmanager/bedrock/models/test_bedrock_response.py
+++ b/test/bestehorn_llmmanager/bedrock/models/test_bedrock_response.py
@@ -591,6 +591,45 @@ class TestBedrockResponse:
         assert "FAILED" in repr_str
 
 
+class TestBedrockResponsePerformanceAndServiceTier:
+    """Tests for get_performance_config / get_service_tier accessors (issue #36)."""
+
+    def test_get_performance_config(self):
+        response_data = {
+            "output": {"message": {"content": [{"text": "ok"}]}},
+            "performanceConfig": {"latency": "optimized"},
+        }
+        response = BedrockResponse(success=True, response_data=response_data)
+        assert response.get_performance_config() == {"latency": "optimized"}
+
+    def test_get_performance_config_absent(self):
+        response = BedrockResponse(
+            success=True, response_data={"output": {"message": {"content": [{"text": "ok"}]}}}
+        )
+        assert response.get_performance_config() is None
+
+    def test_get_performance_config_no_data(self):
+        assert BedrockResponse(success=True, response_data=None).get_performance_config() is None
+
+    def test_get_service_tier(self):
+        response_data = {
+            "output": {"message": {"content": [{"text": "ok"}]}},
+            "serviceTier": {"type": "flex"},
+        }
+        response = BedrockResponse(success=True, response_data=response_data)
+        assert response.get_service_tier() == {"type": "flex"}
+
+    def test_get_service_tier_absent(self):
+        response = BedrockResponse(
+            success=True, response_data={"output": {"message": {"content": [{"text": "ok"}]}}}
+        )
+        assert response.get_service_tier() is None
+
+    def test_get_service_tier_failed_response(self):
+        response = BedrockResponse(success=False, response_data={"serviceTier": {"type": "flex"}})
+        assert response.get_service_tier() is None
+
+
 class TestBedrockResponseStructuredOutput:
     """Tests for get_structured_output (issue #35)."""
 

--- a/test/bestehorn_llmmanager/test_LLMManager.py
+++ b/test/bestehorn_llmmanager/test_LLMManager.py
@@ -342,6 +342,68 @@ class TestLLMManager:
             output_config
         )
 
+    def test_build_converse_request_with_performance_config(self, basic_llm_manager):
+        """performance_config is forwarded as performanceConfig (issue #36)."""
+        messages = [{"role": "user", "content": [{"text": "Hello"}]}]
+        request_args = basic_llm_manager._build_converse_request(
+            messages=messages, performance_config={"latency": "optimized"}
+        )
+        assert request_args[ConverseAPIFields.PERFORMANCE_CONFIG] == {"latency": "optimized"}
+
+    def test_build_converse_request_with_service_tier(self, basic_llm_manager):
+        """service_tier is forwarded as serviceTier (issue #36)."""
+        messages = [{"role": "user", "content": [{"text": "Hello"}]}]
+        request_args = basic_llm_manager._build_converse_request(
+            messages=messages, service_tier={"type": "flex"}
+        )
+        assert request_args[ConverseAPIFields.SERVICE_TIER] == {"type": "flex"}
+
+    def test_build_converse_request_omits_perf_and_tier_by_default(self, basic_llm_manager):
+        """Neither field is added when not provided (backward compatible)."""
+        request_args = basic_llm_manager._build_converse_request(
+            messages=[{"role": "user", "content": [{"text": "Hi"}]}]
+        )
+        assert ConverseAPIFields.PERFORMANCE_CONFIG not in request_args
+        assert ConverseAPIFields.SERVICE_TIER not in request_args
+
+    def test_build_converse_request_extra_request_fields_passthrough(self, basic_llm_manager):
+        """extra_request_fields are merged into the request (forward-compatible escape hatch)."""
+        request_args = basic_llm_manager._build_converse_request(
+            messages=[{"role": "user", "content": [{"text": "Hi"}]}],
+            extra_request_fields={"someFutureField": {"k": "v"}},
+        )
+        assert request_args["someFutureField"] == {"k": "v"}
+
+    def test_build_converse_request_extra_fields_merged_last(self, basic_llm_manager):
+        """extra_request_fields are merged LAST, overriding first-class params on conflict."""
+        request_args = basic_llm_manager._build_converse_request(
+            messages=[{"role": "user", "content": [{"text": "Hi"}]}],
+            service_tier={"type": "default"},
+            extra_request_fields={ConverseAPIFields.SERVICE_TIER: {"type": "flex"}},
+        )
+        assert request_args[ConverseAPIFields.SERVICE_TIER] == {"type": "flex"}
+
+    def test_converse_forwards_performance_and_tier_to_api(self, basic_llm_manager):
+        """converse(performance_config=..., service_tier=...) reach the boto3 call."""
+        mock_client = Mock()
+        mock_client.converse.return_value = {
+            "output": {"message": {"content": [{"text": "ok"}]}},
+            "stopReason": "end_turn",
+        }
+        with patch.object(
+            basic_llm_manager._auth_manager, "get_bedrock_client", return_value=mock_client
+        ):
+            basic_llm_manager.converse(
+                messages=[{"role": "user", "content": [{"text": "Hi"}]}],
+                performance_config={"latency": "optimized"},
+                service_tier={"type": "flex"},
+                extra_request_fields={"futureField": 1},
+            )
+        kwargs = mock_client.converse.call_args.kwargs
+        assert kwargs[ConverseAPIFields.PERFORMANCE_CONFIG] == {"latency": "optimized"}
+        assert kwargs[ConverseAPIFields.SERVICE_TIER] == {"type": "flex"}
+        assert kwargs["futureField"] == 1
+
     def test_get_model_access_info_success(self, basic_llm_manager):
         """Test successful retrieval of model access information."""
         result = basic_llm_manager.get_model_access_info("Claude Haiku 4 5 20251001", "us-east-1")


### PR DESCRIPTION
Closes #36.

## Problem

Two newer top-level Converse request configs were unsupported — `performanceConfig` (latency `standard|optimized`) and `serviceTier` (`priority|default|flex|reserved`) — and neither was echoed back. The shared root cause: `converse()` had a closed signature with no `**kwargs`, so advanced users couldn't reach **any** unmodeled Converse parameter.

## What this adds

- **`performance_config`** and **`service_tier`** parameters on `converse()` / `converse_stream()`, forwarded via `_build_converse_request` to the boto3 `performanceConfig` / `serviceTier` request fields. Echoed back via **`BedrockResponse.get_performance_config()`** / **`get_service_tier()`**.
- **`extra_request_fields`** — a forward-compatible passthrough merged into the request **LAST** (overriding a first-class param on key conflict), so a future top-level Converse parameter can be used **without a library release**. This is the architectural fix that prevents this class of gap recurring.
- The `performanceConfig` / `serviceTier` field constants.

All three are omitted when not provided, so existing calls are byte-for-byte unchanged.

## Design notes

- `extra_request_fields` merges **last** (escape hatch wins on conflict) so a caller can override any first-class param to work around a library issue immediately; documented as the precedence rule. Rationale + alternatives in the spec decision log (DL-001/002).
- `performanceConfig` `{latency}` and `serviceTier` `{type}` shapes taken from the AWS `PerformanceConfiguration` reference and the Converse request syntax (AWS docs MCP).

## Proof

- Unit tests (`test_LLMManager.py`): each param forwarded; both omitted by default; `extra_request_fields` merged; **LAST-merge precedence** (an extra field overrides a first-class param); a **mocked `converse(...)` asserting all three reach the boto3 call**. Response echo-back + None-when-absent/failed in `test_bedrock_response.py::TestBedrockResponsePerformanceAndServiceTier`.
- Full unit suite: **2794 passed, 7 skipped, 0 failed**. New accessors + build branches covered.
- `ruff format --check` ✓, `ruff check` ✓, `mypy --exclude="_version" src/` ✓.
- Independently adversarially verified: 9 mutation-based claims, **0 refuted** (incl. a merge-first mutation confirming the LAST-merge precedence test is non-vacuous).

Streaming `performanceConfig` is already surfaced into `StreamingResponse.metrics_info` (pre-existing, via `get_metrics()`); the non-streaming accessors close the documented gap. No breaking changes.