### PR TITLE
chore(deps): consolidate pending dependency bumps + Dependabot grouping/auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,14 @@ updates:
       prefix: "chore"
       prefix-development: "chore"
       include: "scope"
-    
+    # Batch routine updates into a single PR so they do not accumulate one-per-dependency.
+    # minor/patch are grouped here; majors still open individually for explicit review.
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -34,3 +41,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    # Batch routine action updates into a single PR (majors still open individually).
+    groups:
+      github-actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,35 @@
+name: Dependabot auto-merge
+
+# Auto-merge routine Dependabot PRs once all required status checks pass.
+# Only minor and patch updates are auto-merged; major bumps are left for manual
+# review (a major version change can carry breaking changes). GitHub holds the
+# merge until the branch's required checks (the CI workflow) are green, so a
+# failing bump never merges itself.
+#
+# Requires "Allow auto-merge" enabled in the repository settings.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for minor and patch updates
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+          steps.meta.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,7 +268,7 @@ jobs:
 
     - name: Publish to Test PyPI
       if: needs.build.outputs.is_release_version == 'true'
-      uses: pypa/gh-action-pypi-publish@v1.12.2
+      uses: pypa/gh-action-pypi-publish@v1.14.0
       with:
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true
@@ -284,7 +284,7 @@ jobs:
 
     - name: Publish to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && needs.build.outputs.is_release_version == 'true'
-      uses: pypa/gh-action-pypi-publish@v1.12.2
+      uses: pypa/gh-action-pypi-publish@v1.14.0
       with:
         attestations: false
         verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0,<70.0", "setuptools-scm[toml]>=6.2", "wheel"]
+requires = ["setuptools>=61.0,<83.0", "setuptools-scm[toml]>=6.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/scripts/github_wrapper.py
+++ b/scripts/github_wrapper.py
@@ -431,6 +431,29 @@ def cmd_create_pr(
     )
 
 
+def cmd_list_prs(*, owner: str, repo: str, token: str, state: str) -> None:
+    params: dict[str, Any] = {FIELD_STATE: state, "sort": "created", "direction": "asc"}
+    prs = _paginate(path=f"/repos/{owner}/{repo}/pulls", token=token, params=params)
+    _print(
+        [
+            {
+                "number": pr.get("number"),
+                FIELD_TITLE: pr.get(FIELD_TITLE),
+                FIELD_STATE: pr.get(FIELD_STATE),
+                "draft": pr.get("draft"),
+                "head": pr.get("head", {}).get("ref"),
+                "base": pr.get("base", {}).get("ref"),
+                "user": pr.get("user", {}).get("login"),
+                "created_at": pr.get("created_at"),
+                "updated_at": pr.get("updated_at"),
+                "labels": [lbl.get(FIELD_NAME) for lbl in pr.get(FIELD_LABELS, [])],
+                "html_url": pr.get("html_url"),
+            }
+            for pr in prs
+        ]
+    )
+
+
 def cmd_get_pr(*, owner: str, repo: str, token: str, number: int) -> None:
     pr = _api_request(method="GET", path=f"/repos/{owner}/{repo}/pulls/{number}", token=token)
     reviews = _api_request(
@@ -575,6 +598,9 @@ def main() -> None:
     g.add_argument("--body")
     g.add_argument("--body-file")
 
+    p = sub.add_parser("list-prs")
+    p.add_argument("--state", default="open", choices=["open", "closed", "all"])
+
     for name in ("get-pr", "get-pr-checks", "approve-pr"):
         p = sub.add_parser(name)
         _add_int(p, "number")
@@ -655,6 +681,8 @@ def main() -> None:
             title=args.title,
             body=_body(args),
         )
+    elif cmd == "list-prs":
+        cmd_list_prs(owner=owner, repo=repo, token=token, state=args.state)
     elif cmd == "get-pr":
         cmd_get_pr(owner=owner, repo=repo, token=token, number=args.number)
     elif cmd == "get-pr-checks":


### PR DESCRIPTION
## Summary

Resolves the backlog of open Dependabot PRs and prevents recurrence. Investigation found 6 open Dependabot PRs (oldest from July 2025), all branched off a stale `main`:

- **4 were superseded** — `main` already carries equal-or-newer versions (`actions/checkout@v6`, `actions/setup-python@v6`, `github/codeql-action@v4`, `actions/upload-artifact@v7`). Closed as redundant: #10, #12, #13, #14.
- **2 were genuinely pending** — applied here fresh instead of rebasing the stale, conflicting Dependabot branches:
  - `setuptools` build cap `<70.0` → `<83.0` (Dependabot #6 asked for `<81.0`; raised to `<83.0` so the current setuptools 82.x is actually permitted). Build job verifies it still builds.
  - `pypa/gh-action-pypi-publish` `1.12.2` → `1.14.0` in the release workflow (Dependabot #11 asked for 1.13.0; bumped to the current latest). Both Test PyPI and PyPI publish steps.

## Prevent recurrence
- **Dependabot grouping**: minor/patch updates for `pip` and `github-actions` now batch into a single PR each (majors still open individually for explicit review).
- **Auto-merge workflow**: `.github/workflows/dependabot-auto-merge.yml` enables auto-merge for green minor/patch Dependabot PRs — held until required checks pass; majors excluded. (Requires "Allow auto-merge" in repo settings.)

## Tooling
- Added a `list-prs` subcommand to `scripts/github_wrapper.py` (the wrapper had no way to enumerate PRs).

## Verification
- `ruff format --check` + `ruff check` on `src/ test/ scripts/` — clean.
- `mypy --exclude=_version src/` — clean (108 files).
- Local `python -m build` succeeds under the new `setuptools<83.0` cap.
- All YAML (dependabot.yml, both workflows) parses.

Once #6 and #11 land via this PR they will be closed as carried-by-main.
